### PR TITLE
fix: farming policies ordering and assignment

### DIFF
--- a/substrate-node/pallets/pallet-tfgrid/src/lib.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/lib.rs
@@ -2186,12 +2186,15 @@ impl<T: Config> Pallet<T> {
         };
 
         // Set the farming policy as the last stored farming
-        // policy which certifications are not more qualified
-        // than the current node and farm certifications
+        // policy which certifications best fit the current
+        // node and farm certifications, considering that in all
+        // cases a default policy would be preferable
         let mut policies: Vec<types::FarmingPolicy<T::BlockNumber>> =
             FarmingPoliciesMap::<T>::iter().map(|p| p.1).collect();
 
         policies.sort();
+        // by reversing sorted policies we place default policies first
+        // and then rank them from more certified to less certified
         policies.reverse();
 
         let possible_policy = policies
@@ -2213,13 +2216,15 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-    // Set to se the default farming policy as the last stored default farming policy
+    // Set the default farming policy as the last best certified stored default farming policy
     fn get_default_farming_policy(
     ) -> Result<types::FarmingPolicy<T::BlockNumber>, DispatchErrorWithPostInfo> {
         let mut policies: Vec<types::FarmingPolicy<T::BlockNumber>> =
             FarmingPoliciesMap::<T>::iter().map(|p| p.1).collect();
 
         policies.sort();
+        // by reversing sorted policies we place default policies first
+        // and then rank them from more certified to less certified
         policies.reverse();
 
         let possible_policy = policies

--- a/substrate-node/pallets/pallet-tfgrid/src/tests.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/tests.rs
@@ -2194,7 +2194,7 @@ fn test_bound_twin_account_itself_fails() {
 #[test]
 fn test_farming_policies_ordering_and_assignment() {
     ExternalityBuilder::build().execute_with(|| {
-        let name = "f1".as_bytes().to_vec();
+        let name = b"default_not_certified".to_vec();
         assert_ok!(TfgridModule::create_farming_policy(
             RawOrigin::Root.into(),
             name,
@@ -2210,7 +2210,7 @@ fn test_farming_policies_ordering_and_assignment() {
             FarmCertification::NotCertified,
         ));
 
-        let name: Vec<u8> = "f1certi".as_bytes().to_vec();
+        let name: Vec<u8> = b"fp_1".to_vec();
         assert_ok!(TfgridModule::create_farming_policy(
             RawOrigin::Root.into(),
             name,
@@ -2226,7 +2226,23 @@ fn test_farming_policies_ordering_and_assignment() {
             FarmCertification::NotCertified,
         ));
 
-        let name: Vec<u8> = "f2".as_bytes().to_vec();
+        let name: Vec<u8> = b"default_certified".to_vec();
+        assert_ok!(TfgridModule::create_farming_policy(
+            RawOrigin::Root.into(),
+            name,
+            12,
+            15,
+            10,
+            8,
+            9999,
+            System::block_number() + 100,
+            true,
+            true,
+            NodeCertification::Certified,
+            FarmCertification::Gold,
+        ));
+
+        let name: Vec<u8> = b"fp_2".to_vec();
         assert_ok!(TfgridModule::create_farming_policy(
             RawOrigin::Root.into(),
             name,
@@ -2242,32 +2258,30 @@ fn test_farming_policies_ordering_and_assignment() {
             FarmCertification::NotCertified,
         ));
 
-        let name: Vec<u8> = "f3".as_bytes().to_vec();
-        assert_ok!(TfgridModule::create_farming_policy(
-            RawOrigin::Root.into(),
-            name,
-            12,
-            15,
-            10,
-            8,
-            9999,
-            System::block_number() + 100,
-            false,
-            false,
-            NodeCertification::Diy,
-            FarmCertification::NotCertified,
-        ));
-    
-        
+        let policy_1 = TfgridModule::farming_policies_map(1);
+        let policy_2 = TfgridModule::farming_policies_map(2);
+        let policy_3 = TfgridModule::farming_policies_map(3);
+        let policy_4 = TfgridModule::farming_policies_map(4);
+
+        let mut policies = vec![&policy_1, &policy_2, &policy_3, &policy_4];
+        policies.sort();
+
+        assert_eq!(
+            policies.into_iter().map(|p| p.id).collect::<Vec<_>>(),
+            vec![4, 2, 1, 3]
+        );
+
         create_twin_bob();
         create_farm_bob();
         create_extra_node();
+        let node_id = 1;
 
-        let n = TfgridModule::nodes(1).unwrap();
-        assert_eq!(n.farming_policy_id, 4);
+        // farming policy 1 should be picked
+        // as last "not too certified" default policy
+        let node = TfgridModule::nodes(node_id).unwrap();
+        assert_eq!(node.farming_policy_id, 1);
     })
 }
-
 
 fn create_entity() {
     let name = b"foobar".to_vec();

--- a/substrate-node/pallets/pallet-tfgrid/src/tests.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/tests.rs
@@ -2191,6 +2191,84 @@ fn test_bound_twin_account_itself_fails() {
     })
 }
 
+#[test]
+fn test_farming_policies_ordering_and_assignment() {
+    ExternalityBuilder::build().execute_with(|| {
+        let name = "f1".as_bytes().to_vec();
+        assert_ok!(TfgridModule::create_farming_policy(
+            RawOrigin::Root.into(),
+            name,
+            12,
+            15,
+            10,
+            8,
+            9999,
+            System::block_number() + 100,
+            true,
+            true,
+            NodeCertification::Diy,
+            FarmCertification::NotCertified,
+        ));
+
+        let name: Vec<u8> = "f1certi".as_bytes().to_vec();
+        assert_ok!(TfgridModule::create_farming_policy(
+            RawOrigin::Root.into(),
+            name,
+            12,
+            15,
+            10,
+            8,
+            9999,
+            System::block_number() + 100,
+            false,
+            false,
+            NodeCertification::Certified,
+            FarmCertification::NotCertified,
+        ));
+
+        let name: Vec<u8> = "f2".as_bytes().to_vec();
+        assert_ok!(TfgridModule::create_farming_policy(
+            RawOrigin::Root.into(),
+            name,
+            12,
+            15,
+            10,
+            8,
+            9999,
+            System::block_number() + 100,
+            false,
+            false,
+            NodeCertification::Diy,
+            FarmCertification::NotCertified,
+        ));
+
+        let name: Vec<u8> = "f3".as_bytes().to_vec();
+        assert_ok!(TfgridModule::create_farming_policy(
+            RawOrigin::Root.into(),
+            name,
+            12,
+            15,
+            10,
+            8,
+            9999,
+            System::block_number() + 100,
+            false,
+            false,
+            NodeCertification::Diy,
+            FarmCertification::NotCertified,
+        ));
+    
+        
+        create_twin_bob();
+        create_farm_bob();
+        create_extra_node();
+
+        let n = TfgridModule::nodes(1).unwrap();
+        assert_eq!(n.farming_policy_id, 4);
+    })
+}
+
+
 fn create_entity() {
     let name = b"foobar".to_vec();
     let country = get_country_name_input(b"Belgium");

--- a/substrate-node/pallets/pallet-tfgrid/src/types.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/types.rs
@@ -176,7 +176,10 @@ impl<B: Ord> PartialOrd for FarmingPolicy<B> {
 impl<B: Ord> Ord for FarmingPolicy<B> {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.farm_certification.cmp(&other.farm_certification) {
-            Ordering::Equal => self.node_certification.cmp(&other.node_certification),
+            Ordering::Equal => match self.node_certification.cmp(&other.node_certification) {
+                Ordering::Equal => self.id.cmp(&other.id),
+                ord => ord,
+            }
             ord => ord,
         }
     }

--- a/substrate-node/pallets/pallet-tfgrid/src/types.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/types.rs
@@ -173,19 +173,21 @@ impl<B: Ord> PartialOrd for FarmingPolicy<B> {
     }
 }
 
+// using sort() will place non default policies first, then rank from less certified to more certified
 impl<B: Ord> Ord for FarmingPolicy<B> {
     fn cmp(&self, other: &Self) -> Ordering {
         (
-            other.default,
+            self.default,
             &self.farm_certification,
             &self.node_certification,
             &self.id,
-        ).cmp(&(
-            self.default,
-            &other.farm_certification,
-            &other.node_certification,
-            &other.id,
-        ))
+        )
+            .cmp(&(
+                other.default,
+                &other.farm_certification,
+                &other.node_certification,
+                &other.id,
+            ))
     }
 }
 

--- a/substrate-node/pallets/pallet-tfgrid/src/types.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/types.rs
@@ -175,13 +175,17 @@ impl<B: Ord> PartialOrd for FarmingPolicy<B> {
 
 impl<B: Ord> Ord for FarmingPolicy<B> {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.farm_certification.cmp(&other.farm_certification) {
-            Ordering::Equal => match self.node_certification.cmp(&other.node_certification) {
-                Ordering::Equal => self.id.cmp(&other.id),
-                ord => ord,
-            }
-            ord => ord,
-        }
+        (
+            other.default,
+            &self.farm_certification,
+            &self.node_certification,
+            &self.id,
+        ).cmp(&(
+            self.default,
+            &other.farm_certification,
+            &other.node_certification,
+            &other.id,
+        ))
     }
 }
 


### PR DESCRIPTION
We didn't order farming policies on creation date / id, causing miss assignment of policies on testnet. https://github.com/threefoldtech/tfchain/issues/664