### PR TITLE
refactor: iss735 restructure kvstore pallet

### DIFF
--- a/substrate-node/pallets/pallet-kvstore/src/kvstore.rs
+++ b/substrate-node/pallets/pallet-kvstore/src/kvstore.rs
@@ -1,4 +1,3 @@
-//use super::{*};
 use sp_std::prelude::{Vec};
 use frame_support::pallet_prelude::{DispatchResultWithPostInfo, ensure};
 use super::pallet::{Config, Pallet, TFKVStore, Event, Error};

--- a/substrate-node/pallets/pallet-kvstore/src/kvstore.rs
+++ b/substrate-node/pallets/pallet-kvstore/src/kvstore.rs
@@ -1,26 +1,18 @@
-use sp_std::prelude::{Vec};
-use frame_support::pallet_prelude::{DispatchResultWithPostInfo, ensure};
-use super::pallet::{Config, Pallet, TFKVStore, Event, Error};
+use super::pallet::{Config, Error, Event, Pallet, TFKVStore};
+use frame_support::pallet_prelude::{ensure, DispatchResultWithPostInfo};
+use sp_std::prelude::Vec;
 
 impl<T: Config> Pallet<T> {
-    pub fn _set(
-        user: T::AccountId,
-        key: Vec<u8>,
-        value: Vec<u8>,
-    ) -> DispatchResultWithPostInfo {
+    pub fn _set(user: T::AccountId, key: Vec<u8>, value: Vec<u8>) -> DispatchResultWithPostInfo {
         ensure!(key.len() <= 512, Error::<T>::KeyIsTooLarge);
         ensure!(value.len() <= 2048, Error::<T>::ValueIsTooLarge);
-            
+
         <TFKVStore<T>>::insert(&user, &key, &value);
         Self::deposit_event(Event::EntrySet(user, key, value));
         Ok(().into())
     }
 
-    pub fn _delete(
-        user: T::AccountId,
-        key: Vec<u8>,
-    ) -> DispatchResultWithPostInfo {
-
+    pub fn _delete(user: T::AccountId, key: Vec<u8>) -> DispatchResultWithPostInfo {
         ensure!(
             <TFKVStore<T>>::contains_key(&user, &key),
             Error::<T>::NoValueStored

--- a/substrate-node/pallets/pallet-kvstore/src/kvstore.rs
+++ b/substrate-node/pallets/pallet-kvstore/src/kvstore.rs
@@ -1,0 +1,33 @@
+//use super::{*};
+use sp_std::prelude::{Vec};
+use frame_support::pallet_prelude::{DispatchResultWithPostInfo, ensure};
+use super::pallet::{Config, Pallet, TFKVStore, Event, Error};
+
+impl<T: Config> Pallet<T> {
+    pub fn _set(
+        user: T::AccountId,
+        key: Vec<u8>,
+        value: Vec<u8>,
+    ) -> DispatchResultWithPostInfo {
+        ensure!(key.len() <= 512, Error::<T>::KeyIsTooLarge);
+        ensure!(value.len() <= 2048, Error::<T>::ValueIsTooLarge);
+            
+        <TFKVStore<T>>::insert(&user, &key, &value);
+        Self::deposit_event(Event::EntrySet(user, key, value));
+        Ok(().into())
+    }
+
+    pub fn _delete(
+        user: T::AccountId,
+        key: Vec<u8>,
+    ) -> DispatchResultWithPostInfo {
+
+        ensure!(
+            <TFKVStore<T>>::contains_key(&user, &key),
+            Error::<T>::NoValueStored
+        );
+        let value = <TFKVStore<T>>::take(&user, &key);
+        Self::deposit_event(Event::EntryTaken(user, key, value));
+        Ok(().into())
+    }
+}


### PR DESCRIPTION
**Changes:**
- moving extrinsics logic in `kvstore` pallet out from crate root to separated module.

**Related issues:**
- #735 