### PR TITLE
fix: use base block weight for runtime upgrade call

### DIFF
--- a/substrate-node/pallets/pallet-runtime-upgrade/src/lib.rs
+++ b/substrate-node/pallets/pallet-runtime-upgrade/src/lib.rs
@@ -22,7 +22,7 @@ pub mod pallet {
     impl<T: Config> Pallet<T> {
         #[pallet::call_index(0)]
         // Give same weight as set_code() wrapped extrinsic from frame_system
-        #[pallet::weight((T::BlockWeights::get().max_block, DispatchClass::Operational))]
+        #[pallet::weight((T::BlockWeights::get().base_block, DispatchClass::Operational))]
         pub fn set_code(origin: OriginFor<T>, code: Vec<u8>) -> DispatchResultWithPostInfo {
             T::SetCodeOrigin::ensure_origin(origin)?;
             frame_system::Pallet::<T>::set_code(frame_system::RawOrigin::Root.into(), code)?;

--- a/tools/fork-off-substrate/index.js
+++ b/tools/fork-off-substrate/index.js
@@ -148,6 +148,8 @@ async function main() {
   if (alice !== '') {
     // Set sudo key to //Alice
     forkedSpec.genesis.raw.top['0x5c0d1176a568c1f92944340dbfed9e9c530ebca703c85910e7164cb7d1c9e47b'] = '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d';
+    // Council
+    forkedSpec.genesis.raw.top['0xaebd463ed9925c488c112434d61debc0ba7fb8745735dc3be2a2c61a72c39e78'] = '0x0c1cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d'
     // Pallet validator validators
     forkedSpec.genesis.raw.top['0x7d9fe37370ac390779f35763d98106e888dcde934c658227ee1dfafcd6e16903'] = '0x04d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d';
     // Session validators


### PR DESCRIPTION
Also adds council members (alice, bob and ferdie) as defaults when forking a live chain. This to support the removal of sudo pallet when development on a fork of a live chain is required.