### PR TITLE
feat: iss#840 sync component version with repo version

### DIFF
--- a/activation-service/helm/tfchainactivationservice/Chart.yaml
+++ b/activation-service/helm/tfchainactivationservice/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tfchainactivationservice
 description: TFchain account activation funding service
 type: application
-version: 0.1.3
+version: 2.5.0-rc7
 appVersion: "2.5.0-rc7"

--- a/activation-service/package.json
+++ b/activation-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "substrate-funding-service",
-  "version": "0.0.1",
+  "version": "2.5.0-rc7",
   "description": "Substrate funding service",
   "main": "index.js",
   "scripts": {

--- a/bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml
+++ b/bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml
@@ -4,6 +4,6 @@ description: Bridge for TFT between Tfchain Stellar
 
 type: application
 
-version: 0.2.2
+version: 2.5.0-rc7
 
 appVersion: '2.5.0-rc7'

--- a/clients/tfchain-client-js/package.json
+++ b/clients/tfchain-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfgrid-api-client",
-  "version": "1.29.1",
+  "version": "2.5.0-rc7",
   "description": "API client for the TF Grid",
   "main": "index.js",
   "scripts": {

--- a/docs/production/releases.md
+++ b/docs/production/releases.md
@@ -15,6 +15,10 @@ Releases are automated by [this workflow](.github/workflows/030_create_release.y
     - Increment package `version` in [package.json](../../activation-service/package.json)
 - Js TFchin Client
     - Increment package `version` in [package.json](../../clients/tfchain-client-js/package.json)
+- Scripts
+    - Increment package `version` in [package.json](../../scripts/package.json)
+- Tools/fork-off-substrate
+    - Increment package `version` in [package.json](../../tools/fork-off-substrate/package.json)
 
 - Commit the changes
 - Create a new tag with the version number prefixed with a `v` (e.g. `v1.0.0`, `v1.0.0-rc1` for release candidates) 

--- a/docs/production/releases.md
+++ b/docs/production/releases.md
@@ -13,7 +13,7 @@ Releases are automated by [this workflow](.github/workflows/030_create_release.y
     - Increment chart `appVersion` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
     - Increment chart `version` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
     - Increment package `version` in [package.json](../../activation-service/package.json)
-- Js TFchin Client
+- Js TFChain Client
     - Increment package `version` in [package.json](../../clients/tfchain-client-js/package.json)
 - Scripts
     - Increment package `version` in [package.json](../../scripts/package.json)

--- a/docs/production/releases.md
+++ b/docs/production/releases.md
@@ -13,6 +13,9 @@ Releases are automated by [this workflow](.github/workflows/030_create_release.y
     - Increment chart `appVersion` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
     - Increment chart `version` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
     - Increment package `version` in [package.json](../../activation-service/package.json)
+- Js TFchin Client
+    - Increment package `version` in [package.json](../../clients/tfchain-client-js/package.json)
+
 - Commit the changes
 - Create a new tag with the version number prefixed with a `v` (e.g. `v1.0.0`, `v1.0.0-rc1` for release candidates) 
 - Push the tag to the repository

--- a/docs/production/releases.md
+++ b/docs/production/releases.md
@@ -2,10 +2,17 @@
 
 Releases are automated by [this workflow](.github/workflows/030_create_release.yaml). When a release should be created following things need to be done:
 
-- Increment spec version in the [runtime](./substrate-node/runtime/src/lib.rs) 
-- Increment version in [Cargo.toml](./substrate-node/Cargo.toml)
-- Increment version in [Chart.yaml](./substrate-node/charts/substrate-node/Chart.yaml)
-- Increment version in [Chart.yaml](./bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
+- substrate-node
+    - Increment spec version in the runtime [lib.rs](../../substrate-node/runtime/src/lib.rs) 
+    - Increment version in [Cargo.toml](../../substrate-node/Cargo.toml)
+    - Increment package `version` filed in [Chart.yaml](../../substrate-node/charts/substrate-node/Chart.yaml)
+- tfchainbridge
+    - Increment chart `appVersion` filed in [Chart.yaml](../../bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
+    - Increment chart ` version` filed in [Chart.yaml](../../bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
+- activation-service
+    - Increment chart `appVersion` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
+    - Increment chart `version` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
+    - Increment package `version` in [package.json](../../activation-service/package.json)
 - Commit the changes
 - Create a new tag with the version number prefixed with a `v` (e.g. `v1.0.0`, `v1.0.0-rc1` for release candidates) 
 - Push the tag to the repository

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfchain-js-scripts",
-  "version": "1.0.0",
+  "version": "2.5.0-rc7",
   "description": "scripts to fetch data / write data to tfchain",
   "main": "index.js",
   "scripts": {

--- a/substrate-node/charts/substrate-node/Chart.yaml
+++ b/substrate-node/charts/substrate-node/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: substrate-node
 description: Tfchain node
 type: application
-version: 0.3.0
+version: 2.5.0-rc7
 appVersion: '2.5.0-rc7'

--- a/tools/fork-off-substrate/package.json
+++ b/tools/fork-off-substrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-off-substrate",
-  "version": "1.0.0",
+  "version": "2.5.0-rc7",
   "description": "This script allows bootstrapping a new substrate chain with the current state of a live chain",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**The motivation behind this PR**:
Whenever we change our chart files, we need to update the chart version field. This helps us prevent conflicts with other chart versions and track the changes. I know that appVersion and version are not related, but I used the same version here for simplicity as we should pump both version with every release anyway.

There is also a mismatch between the appVersion field in the activation-service chart and the actual app version  (the one in package.json).

**What's changed**:
- Update `version` in activation-service `package.json` to match the repo and appVersion in actiavtion service helm chart file
- Update `version` in activation-service chart file. 
- Update `version` in tfchain-bridge chart file
- Update `version` in substrate-node chart file
- Update the release doc to reflect the changes above.
- Update `version` in  JS client `package.json`.

**Related Issues**:
#840 