### PR TITLE
fix: adjust activation service workflow

### DIFF
--- a/.github/workflows/040_publish_activation_service_image.yml
+++ b/.github/workflows/040_publish_activation_service_image.yml
@@ -26,13 +26,14 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/threefoldtech/tfchain_activation_service
           tags: |
             type=semver,pattern={{version}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
+          context: ./activation-service
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/activation-service/helm/tfchainactivationservice/Chart.yaml
+++ b/activation-service/helm/tfchainactivationservice/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tfchainactivationservice
 description: TFchain account activation funding service
 type: application
-version: 0.1.3
+version: 2.5.0-rc7
 appVersion: "2.5.0-rc7"

--- a/activation-service/package.json
+++ b/activation-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "substrate-funding-service",
-  "version": "0.0.1",
+  "version": "2.5.0-rc7",
   "description": "Substrate funding service",
   "main": "index.js",
   "scripts": {

--- a/bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml
+++ b/bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml
@@ -4,6 +4,6 @@ description: Bridge for TFT between Tfchain Stellar
 
 type: application
 
-version: 0.2.2
+version: 2.5.0-rc7
 
 appVersion: '2.5.0-rc7'

--- a/docs/production/releases.md
+++ b/docs/production/releases.md
@@ -2,10 +2,17 @@
 
 Releases are automated by [this workflow](.github/workflows/030_create_release.yaml). When a release should be created following things need to be done:
 
-- Increment spec version in the [runtime](./substrate-node/runtime/src/lib.rs) 
-- Increment version in [Cargo.toml](./substrate-node/Cargo.toml)
-- Increment version in [Chart.yaml](./substrate-node/charts/substrate-node/Chart.yaml)
-- Increment version in [Chart.yaml](./bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
+- substrate-node
+    - Increment spec version in the runtime [lib.rs](../../substrate-node/runtime/src/lib.rs) 
+    - Increment version in [Cargo.toml](../../substrate-node/Cargo.toml)
+    - Increment package `version` filed in [Chart.yaml](../../substrate-node/charts/substrate-node/Chart.yaml)
+- tfchainbridge
+    - Increment chart `appVersion` filed in [Chart.yaml](../../bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
+    - Increment chart ` version` filed in [Chart.yaml](../../bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
+- activation-service
+    - Increment chart `appVersion` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
+    - Increment chart `version` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
+    - Increment package `version` in [package.json](../../activation-service/package.json)
 - Commit the changes
 - Create a new tag with the version number prefixed with a `v` (e.g. `v1.0.0`, `v1.0.0-rc1` for release candidates) 
 - Push the tag to the repository

--- a/substrate-node/charts/substrate-node/Chart.yaml
+++ b/substrate-node/charts/substrate-node/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: substrate-node
 description: Tfchain node
 type: application
-version: 0.3.0
+version: 2.5.0-rc7
 appVersion: '2.5.0-rc7'


### PR DESCRIPTION
should triggered on publish release, for a release like v1.0.0 ,  it will pushed to `ghcr.io/threefoldtech/tfchain_activation_service` and taged the image with `1.0.0` tag

- move the workflow to root .github/workflows/
- specify the subdirectory as the context
