### PR TITLE
fix: iss#841 adjust activation-service workflow

### DIFF
--- a/.github/workflows/040_publish_activation_service_image.yml
+++ b/.github/workflows/040_publish_activation_service_image.yml
@@ -26,13 +26,14 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/threefoldtech/tfchain_activation_service
           tags: |
             type=semver,pattern={{version}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
+          context: ./activation-service
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
**What's changed:**
- Move the workflow to root .github/workflows/
- Specify the subdirectory as the context
- Adjust image name to `ghcr.io/threefoldtech/tfchain_activation_service` 

This workflow should triggered on publish release, and for a release like `v1.0.0` , it will build and push the activation-service image to `ghcr.io/threefoldtech/tfchain_activation_service` and tag it with `1.0.0` tag.

**Related Issues:**
https://github.com/threefoldtech/tfchain/issues/841