### PR TITLE
ci: switch from auto generated GITHUB_TOKEN to PAT

### DIFF
--- a/.github/workflows/030_create_release.yaml
+++ b/.github/workflows/030_create_release.yaml
@@ -91,7 +91,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_KEY }}
         with:
           tag_name: ${{ github.ref }}
           name: Release ${{ github.ref_name }}

--- a/.github/workflows/040_publish_activation_service_image.yml
+++ b/.github/workflows/040_publish_activation_service_image.yml
@@ -1,6 +1,7 @@
 name: Publish Docker image
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 


### PR DESCRIPTION
## Description

- What does this PR do?
Switching from auto generated GITHUB_TOKEN to PAT in release workflow

- Why are these changes needed?
Triggering a workflow from a workflow that uses automatic GITHUB_TOKEN won't work.
This why The release created by by `create_release` workflow won't trigger workflow `publich-activation-service-image`. for more info about this [see here](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)

- How were these changes implemented and what do they affect?
Next time `create_release` runs it should trigger properly `publich-activation-service-image` workflow.

## Checklist:

- [X] My commits follow this [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guide.
