### PR TITLE
Development fix dao proposal veto

### DIFF
--- a/docs/architecture/0015-duplicate-veto.md
+++ b/docs/architecture/0015-duplicate-veto.md
@@ -1,0 +1,16 @@
+# 15. Prevent DAO proposal from duplicate veto
+
+Date: 2023-09-14
+
+## Status
+
+Accepted
+
+## Context
+
+See [here](https://github.com/threefoldtech/tfchain/issues/858) for more details.
+
+## Decision
+
+Since we don't want a council member to veto a DAO proposal alone by being able to submit its veto more than once we need to prevent duplicate veto.
+In `pallet-dao`, `veto()` extrinsic should return an appropriate error while this situation occures.

--- a/substrate-node/pallets/pallet-dao/src/dao.rs
+++ b/substrate-node/pallets/pallet-dao/src/dao.rs
@@ -173,6 +173,8 @@ impl<T: Config> Pallet<T> {
             Error::<T>::WrongIndex
         );
 
+        ensure!(!voting.vetos.contains(&who), Error::<T>::DuplicateVeto);
+
         voting.vetos.push(who.clone());
 
         Self::deposit_event(Event::CouncilMemberVeto { proposal_hash, who });

--- a/substrate-node/pallets/pallet-dao/src/lib.rs
+++ b/substrate-node/pallets/pallet-dao/src/lib.rs
@@ -170,6 +170,7 @@ pub mod pallet {
         ProposalMissing,
         WrongIndex,
         DuplicateVote,
+        DuplicateVeto,
         WrongProposalWeight,
         TooEarly,
         TimeLimitReached,

--- a/substrate-node/pallets/pallet-dao/src/mock.rs
+++ b/substrate-node/pallets/pallet-dao/src/mock.rs
@@ -3,11 +3,10 @@ use crate::{self as pallet_dao};
 use frame_support::{construct_runtime, parameter_types, traits::ConstU32, BoundedVec};
 use frame_system::EnsureRoot;
 use pallet_collective;
-use pallet_tfgrid::node::{CityName, CountryName};
 use pallet_tfgrid::{
     farm::FarmName,
     interface::{InterfaceIp, InterfaceMac, InterfaceName},
-    node::{Location, SerialNumber},
+    node::{CityName, CountryName, Location, SerialNumber},
     terms_cond::TermsAndConditions,
     CityNameInput, CountryNameInput, DocumentHashInput, DocumentLinkInput, Gw4Input, Ip4Input,
     LatitudeInput, LongitudeInput, PkInput, RelayInput,


### PR DESCRIPTION
## Description

A duplicate veto from a council member should not be allowed.
Make sure this can not happen by sending appropriate error message in `veto()` call if a veto from such council member is already registered.

## Related Issues:

- Fixes #858 



