### PR TITLE
chore: bump to version 2.6.0-rc1 (specVersion: 146)

### DIFF
--- a/activation-service/helm/tfchainactivationservice/Chart.yaml
+++ b/activation-service/helm/tfchainactivationservice/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tfchainactivationservice
 description: TFchain account activation funding service
 type: application
-version: 2.5.0-rc7
-appVersion: "2.5.0-rc7"
+version: 2.6.0-rc1
+appVersion: '2.6.0-rc1'

--- a/activation-service/package.json
+++ b/activation-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "substrate-funding-service",
-  "version": "2.5.0-rc7",
+  "version": "2.6.0-rc1",
   "description": "Substrate funding service",
   "main": "index.js",
   "scripts": {

--- a/bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml
+++ b/bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml
@@ -1,9 +1,6 @@
 apiVersion: v2
 name: tfchainbridge
 description: Bridge for TFT between Tfchain Stellar
-
 type: application
-
-version: 2.5.0-rc7
-
-appVersion: '2.5.0-rc7'
+version: 2.6.0-rc1
+appVersion: '2.6.0-rc1'

--- a/clients/tfchain-client-js/package.json
+++ b/clients/tfchain-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfgrid-api-client",
-  "version": "2.5.0-rc7",
+  "version": "2.6.0-rc1",
   "description": "API client for the TF Grid",
   "main": "index.js",
   "scripts": {

--- a/docs/production/releases.md
+++ b/docs/production/releases.md
@@ -2,28 +2,37 @@
 
 Releases are automated by [this workflow](.github/workflows/030_create_release.yaml). When a release should be created following things need to be done:
 
-- substrate-node
-    - Increment spec version in the runtime [lib.rs](../../substrate-node/runtime/src/lib.rs) 
-    - Increment version in [Cargo.toml](../../substrate-node/Cargo.toml)
-    - Increment package `version` filed in [Chart.yaml](../../substrate-node/charts/substrate-node/Chart.yaml)
-- tfchainbridge
-    - Increment chart `appVersion` filed in [Chart.yaml](../../bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
-    - Increment chart ` version` filed in [Chart.yaml](../../bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
-- activation-service
-    - Increment chart `appVersion` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
-    - Increment chart `version` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
-    - Increment package `version` in [package.json](../../activation-service/package.json)
-- Js TFChain Client
-    - Increment package `version` in [package.json](../../clients/tfchain-client-js/package.json)
-- Scripts
-    - Increment package `version` in [package.json](../../scripts/package.json)
-- Tools/fork-off-substrate
-    - Increment package `version` in [package.json](../../tools/fork-off-substrate/package.json)
+*   substrate-node
+    *   Increment spec version in the runtime [lib.rs](../../substrate-node/runtime/src/lib.rs)
+    *   Increment version in [Cargo.toml](../../substrate-node/Cargo.toml)
+    *   Increment chart `version` filed in [Chart.yaml](../../substrate-node/charts/substrate-node/Chart.yaml)
+    *   Increment chart `appVersion` filed in [Chart.yaml](../../substrate-node/charts/substrate-node/Chart.yaml)
 
-- Commit the changes
-- Create a new tag with the version number prefixed with a `v` (e.g. `v1.0.0`, `v1.0.0-rc1` for release candidates) 
-- Push the tag to the repository
-- The workflow will create a release draft with the changelog and the binaries attached
+*   tfchainbridge
+    *   Increment chart `version` filed in [Chart.yaml](../../bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
+    *   Increment chart `appVersion` filed in [Chart.yaml](../../bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
+
+*   activation-service
+    *   Increment chart `version` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
+    *   Increment chart `appVersion` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
+    *   Increment package `version` in [package.json](../../activation-service/package.json)
+
+*   Js TFChain Client
+    *   Increment package `version` in [package.json](../../clients/tfchain-client-js/package.json)
+
+*   Scripts
+    *   Increment package `version` in [package.json](../../scripts/package.json)
+
+*   Tools/fork-off-substrate
+    *   Increment package `version` in [package.json](../../tools/fork-off-substrate/package.json)
+
+*   Commit the changes
+
+*   Create a new tag with the version number prefixed with a `v` (e.g. `v1.0.0`, `v1.0.0-rc1` for release candidates)
+
+*   Push the tag to the repository
+
+*   The workflow will create a release draft with the changelog and the binaries attached
 
 A changelog will be generated based on the Pull requests merged, so having PRs with meaningful titles is important.
 
@@ -33,6 +42,5 @@ See [validate](../misc/validating_runtime.md) for instructions on how to validat
 
 ### Upgrade runtime
 
-To upgrade the runtime for a network based on a release, download the runtime attached to the release (tfchain_runtime.compact.compressed.wasm)
+To upgrade the runtime for a network based on a release, download the runtime attached to the release (tfchain\_runtime.compact.compressed.wasm)
 and upload it to the network using a council proposal. The proposal should be a `set_code` proposal with the runtime as the code and majority of the council should vote in favor of the proposal.
-

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfchain-js-scripts",
-  "version": "2.5.0-rc7",
+  "version": "2.6.0-rc1",
   "description": "scripts to fetch data / write data to tfchain",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "author": "",
   "license": "ISC",
-    "dependencies": {
+  "dependencies": {
     "@polkadot/api": "^10.7.2",
     "axios": "^0.25.0",
     "bip39": "^3.0.3",

--- a/substrate-node/Cargo.lock
+++ b/substrate-node/Cargo.lock
@@ -4645,7 +4645,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-burning"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4680,7 +4680,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-dao"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-kvstore"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4759,7 +4759,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-runtime-upgrade"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4825,7 +4825,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-smart-contract"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-tfgrid"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -4905,7 +4905,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-tft-bridge"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-tft-price"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5027,7 +5027,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-validator"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8518,7 +8518,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-validator-set"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8664,7 +8664,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tfchain"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 dependencies = [
  "clap",
  "frame-benchmarking",
@@ -8708,7 +8708,7 @@ dependencies = [
 
 [[package]]
 name = "tfchain-runtime"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -8762,7 +8762,7 @@ dependencies = [
 
 [[package]]
 name = "tfchain-support"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/substrate-node/Cargo.toml
+++ b/substrate-node/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://threefold.io/"
 license-file = "LICENSE"
 readme = "README.md"
 repository = "https://github.com/threefoldtech/tfchain3"
-version = "2.5.0-rc7"
+version = "2.6.0-rc1"
 
 [workspace]
 members = [

--- a/substrate-node/charts/substrate-node/Chart.yaml
+++ b/substrate-node/charts/substrate-node/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: substrate-node
 description: Tfchain node
 type: application
-version: 2.5.0-rc7
-appVersion: '2.5.0-rc7'
+version: 2.6.0-rc1
+appVersion: '2.6.0-rc1'

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -147,7 +147,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("substrate-threefold"),
     impl_name: create_runtime_str!("substrate-threefold"),
     authoring_version: 1,
-    spec_version: 145,
+    spec_version: 146,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -770,13 +770,7 @@ pub type Executive = frame_executive::Executive<
 
 // All migrations executed on runtime upgrade as a nested tuple of types implementing
 // `OnRuntimeUpgrade`.
-type Migrations = (
-    // pallet_tfgrid::migrations::v16::KillNodeGpuStatus<Runtime>,
-    // pallet_smart_contract::migrations::v10::ReworkBillingLoopInsertion<Runtime>,
-    // pallet_smart_contract::migrations::v11::ExtendContractLock<Runtime>,
-    // migrations::remove_sudo::RemoveSudo<Runtime>,
-    pallet_tfgrid::migrations::v17::FixFarmPublicIps<Runtime>,
-);
+type Migrations = (pallet_tfgrid::migrations::v17::FixFarmPublicIps<Runtime>,);
 
 // follows Substrate's non destructive way of eliminating  otherwise required
 // repetion: https://github.com/paritytech/substrate/pull/10592

--- a/tools/fork-off-substrate/package.json
+++ b/tools/fork-off-substrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-off-substrate",
-  "version": "2.5.0-rc7",
+  "version": "2.6.0-rc1",
   "description": "This script allows bootstrapping a new substrate chain with the current state of a live chain",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Description

Bump TFChain to version 2.6.0-rc1 (specVersion: 146)

## Checklist:

- [x] I followed the **[Release](https://github.com/threefoldtech/tfchain/blob/development/docs/production/releases.md)** document.
- [x] My commits follow this [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guide.
