### PR TITLE
docs: updating obsolete links

### DIFF
--- a/bridge/docs/development.md
+++ b/bridge/docs/development.md
@@ -7,7 +7,7 @@ See [installing](./install.md)
 ## Prerequisites:
 
 - Install and run [tfchain](https://github.com/threefoldtech/tfchain/blob/development/docs/development)
-- Install [stellar-utils-tool](https://github.com/threefoldfoundation/tft/tree/main/bsc/bridges/stellar/utils)
+- Install [stellar-utils-tool](https://github.com/threefoldfoundation/tft/tree/main/tools/bridgegen)
 
 ## Local single node development
 

--- a/bridge/docs/install.md
+++ b/bridge/docs/install.md
@@ -13,8 +13,8 @@ echo export PATH=\"\$PATH:\$GOPATH/bin\" >> ~/.bash_profile
 ### Get Source Code
 
 ```sh
-git clone https://github.com/threefoldtech/tfchain_tft_bridge.git
-cd tfchain_tft_bridge/tfchain_bridge
+git clone https://github.com/threefoldtech/tfchain.git
+cd bridge/tfchain_bridge
 ```
 
 ### Compile

--- a/bridge/tfchain_bridge/readme.md
+++ b/bridge/tfchain_bridge/readme.md
@@ -2,4 +2,4 @@
 
 TFT Bridge between Tfchain and stellar.
 
-See [docs](./docs/readme.md) for more information.
+See [docs](../docs/readme.md) for more information.


### PR DESCRIPTION
## Description

- updating/fixing obsolete links in the bridge documentations.

## Checklist:

- [X] My commits follow this [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guide.
