### PR TITLE
Add tx hash to mintCompleted event

### DIFF
--- a/clients/tfchain-client-go/tft_bridge_events.go
+++ b/clients/tfchain-client-go/tft_bridge_events.go
@@ -103,7 +103,7 @@ type MintTransactionVoted struct {
 type MintCompleted struct {
 	Phase           types.Phase
 	MintTransaction MintTransaction `json:"mint_transaction"`
-	TxHash string    `json:"tx_hash"`
+	TxHash          string          `json:"tx_hash"`
 	Topics          []types.Hash
 }
 

--- a/clients/tfchain-client-go/tft_bridge_events.go
+++ b/clients/tfchain-client-go/tft_bridge_events.go
@@ -103,6 +103,7 @@ type MintTransactionVoted struct {
 type MintCompleted struct {
 	Phase           types.Phase
 	MintTransaction MintTransaction `json:"mint_transaction"`
+	TxHash string    `json:"tx_hash"`
 	Topics          []types.Hash
 }
 

--- a/substrate-node/pallets/pallet-tft-bridge/src/benchmarking.rs
+++ b/substrate-node/pallets/pallet-tft-bridge/src/benchmarking.rs
@@ -107,7 +107,7 @@ benchmarks! {
         ));
 
         let validator: T::AccountId = account("Alice", 0, 0);
-    }: _(RawOrigin::Signed(validator), tx_id, target.clone(), amount)
+    }: _(RawOrigin::Signed(validator), tx_id.clone(), target.clone(), amount)
     verify {
         let block = System::<T>::block_number();
         let mint_tx = MintTransaction { amount, target, block, votes: 3 };

--- a/substrate-node/pallets/pallet-tft-bridge/src/benchmarking.rs
+++ b/substrate-node/pallets/pallet-tft-bridge/src/benchmarking.rs
@@ -111,7 +111,7 @@ benchmarks! {
     verify {
         let block = System::<T>::block_number();
         let mint_tx = MintTransaction { amount, target, block, votes: 3 };
-        assert_last_event::<T>(Event::MintCompleted(mint_tx).into());
+        assert_last_event::<T>(Event::MintCompleted(mint_tx, tx_id).into());
     }
 
     // propose_burn_transaction_or_add_sig

--- a/substrate-node/pallets/pallet-tft-bridge/src/lib.rs
+++ b/substrate-node/pallets/pallet-tft-bridge/src/lib.rs
@@ -131,7 +131,7 @@ pub mod pallet {
         // Minting events
         MintTransactionProposed(Vec<u8>, T::AccountId, u64),
         MintTransactionVoted(Vec<u8>),
-        MintCompleted(MintTransaction<T::AccountId, T::BlockNumber>),
+        MintCompleted(MintTransaction<T::AccountId, T::BlockNumber>, Vec<u8>),
         MintTransactionExpired(Vec<u8>, u64, T::AccountId),
         // Burn events
         BurnTransactionCreated(u64, T::AccountId, Vec<u8>, u64),

--- a/substrate-node/pallets/pallet-tft-bridge/src/tft_bridge.rs
+++ b/substrate-node/pallets/pallet-tft-bridge/src/tft_bridge.rs
@@ -39,9 +39,9 @@ impl<T: Config> Pallet<T> {
         // Insert into executed transactions
         let now = <system::Pallet<T>>::block_number();
         tx.block = now;
-        ExecutedMintTransactions::<T>::insert(tx_id, &tx);
+        ExecutedMintTransactions::<T>::insert(tx_id.clone(), &tx);
 
-        Self::deposit_event(Event::MintCompleted(tx));
+        Self::deposit_event(Event::MintCompleted(tx, tx_id));
 
         Ok(().into())
     }


### PR DESCRIPTION
## Description

This PR add the tx hash to the MintCompleted event for better observbility and event correlation in the bridge.

## Related Issues:

- Closes #882

## Checklist:
- [X] My commits follow this [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guide.
