### PR TITLE
fix(pallet-dao): expired proposal approval

### DIFF
--- a/substrate-node/pallets/pallet-dao/src/tests.rs
+++ b/substrate-node/pallets/pallet-dao/src/tests.rs
@@ -263,6 +263,52 @@ fn close_after_proposal_duration_works() {
 }
 
 #[test]
+fn close_after_proposal_duration_threshold_not_met_works() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+
+        let proposal = make_proposal(b"some_remark".to_vec());
+        let hash = BlakeTwo256::hash_of(&proposal);
+        let threshold = 2;
+
+        assert_ok!(DaoModule::propose(
+            RuntimeOrigin::signed(1),
+            threshold,
+            Box::new(proposal.clone()),
+            b"some_description".to_vec(),
+            b"some_link".to_vec(),
+            None
+        ));
+        let proposal_index = 0;
+
+        // Farmer 1 votes yes
+        let farm_id = 1;
+        prepare_twin_farm_and_node(10, b"farm1".to_vec(), farm_id);
+        assert_ok!(DaoModule::vote(
+            RuntimeOrigin::signed(10),
+            farm_id,
+            hash.clone(),
+            true
+        ));
+
+        System::set_block_number(5); // default duration is 4 blocks
+        assert_ok!(DaoModule::close(
+            RuntimeOrigin::signed(2),
+            hash.clone(),
+            proposal_index
+        ));
+
+        let e = System::events();
+        assert_eq!(
+            e[6],
+            record(MockEvent::DaoModule(DaoEvent::Disapproved {
+                proposal_hash: hash,
+            }))
+        );
+    });
+}
+
+#[test]
 fn close_if_not_council_member_fails() {
     new_test_ext().execute_with(|| {
         let proposal = make_proposal(b"some_remark".to_vec());


### PR DESCRIPTION
## Description

When closing a proposal, modify its behavior to reflect the following statement `threshold = number minimum of votes below which the proposal can not be approved`.
In result, while closing a proposal after it expired it will not be approved without having at least the minimum number of voters specified by `threshold` value.

## Related Issues:

- Fixes #803

## Checklist:

Please delete options that are not relevant.

- [x] I have added tests to cover my changes.
- [x] My commits follow this [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guide.
