### PR TITLE
ci: build tfchain image

### DIFF
--- a/.github/workflows/060_publish_tfchain_image.yml
+++ b/.github/workflows/060_publish_tfchain_image.yml
@@ -1,0 +1,42 @@
+name: Publish tfchain image
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/threefoldtech/tfchain
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          file: ./substrate-node/Dockerfile
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/substrate-node/Dockerfile
+++ b/substrate-node/Dockerfile
@@ -1,36 +1,40 @@
 FROM docker.io/paritytech/ci-linux:production as builder
 
 WORKDIR /tfchain
-
 ARG FEATURES=default
-
 COPY . .
-
 RUN cargo build --locked --release --features $FEATURES
 
 # ===== SECOND STAGE ======
-
-FROM docker.io/library/ubuntu:20.04
-LABEL maintainer="dylan@threefold.tech"
-LABEL description="This is the 2nd stage: a very small image where we copy the tfchain binary."
+FROM docker.io/library/ubuntu:22.04
 ARG PROFILE=release
+# metadata
+ARG DOC_URL="https://github.com/threefoldtech/tfchain"
+
+LABEL io.threefoldtech.image.authors="https://www.threefold.tech" \
+	io.threefoldtech.image.vendor="Threefold Tech" \
+	io.threefoldtech.image.title="threefoldtech/tfchain" \
+	io.threefoldtech.image.description="A base image for standard binary distribution" \
+	io.threefoldtech.image.source="https://github.com/threefoldtech/tfchain/blob/development/substrate-node/Dockerfile" \
+	io.threefoldtech.image.documentation="${DOC_URL}"
+
+# show backtraces
+ENV RUST_BACKTRACE 1
 
 COPY --from=builder /tfchain/target/$PROFILE/tfchain /usr/local/bin
 COPY --from=builder /tfchain/chainspecs /etc/chainspecs/
 
-# checks	
-RUN ldd /usr/local/bin/tfchain && \
-	/usr/local/bin/tfchain --version
-
-# Install CA certificates not present in base image
-RUN apt-get update
-RUN apt-get install -y curl
-RUN apt-get install -y ca-certificates
-
-# Shrinking
-RUN rm -rf /usr/lib/python* && \
+RUN apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+	libssl3 ca-certificates && \
+	apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* && \
+	rm -rf /usr/lib/python* && \
 	rm -rf /src && \
 	rm -rf /usr/share/man
+
+# checks
+RUN ldd /usr/local/bin/tfchain && \
+	/usr/local/bin/tfchain --version
 
 EXPOSE 30333 9933 9944 9615
 VOLUME ["/tfchain"]


### PR DESCRIPTION
## Description
- include binary distribution image in the build process

## Related Issues:
- Fixes #897

