### PR TITLE
Fix failing yarn install on docker build

### DIFF
--- a/activation-service/Dockerfile
+++ b/activation-service/Dockerfile
@@ -4,11 +4,10 @@ FROM node:16
 WORKDIR /usr/src/app
 
 # Install app dependencies
-# A wildcard is used to ensure both package.json AND package-lock.json are copied
-# where available (npm@5+)
-COPY package*.json ./
+COPY package.json yarn.lock ./
 
-RUN yarn install
+RUN yarn install && yarn cache clean
+
 # If you are building your code for production
 # RUN npm ci --only=production
 


### PR DESCRIPTION
## Description

CI was failing recently to build the activation service image due to some dependencies changes.
I checked to find that although we are using `yarn` in the docker file we are copying the npm's lock file instead of the `yarn.lock` 

This PR should fix the image and the CI, also optimize the image size.

## Related Issues:

- Fixes #916 
