### PR TITLE
feat(pallet-tfgrid): rework change power target on node

### DIFF
--- a/clients/tfchain-client-go/utils.go
+++ b/clients/tfchain-client-go/utils.go
@@ -243,6 +243,7 @@ var tfgridModuleErrors = []string{
 	"InvalidDocumentHashInput",
 	"InvalidPublicConfig",
 	"UnauthorizedToChangePowerTarget",
+	"NodeHasActiveContracts",
 	"InvalidRelayAddress",
 	"InvalidTimestampHint",
 }

--- a/docs/architecture/0019-rework_change_power_target.md
+++ b/docs/architecture/0019-rework_change_power_target.md
@@ -1,0 +1,15 @@
+# 19. Rework change power target on node
+
+Date: 2024-01-09
+
+## Status
+
+Accepted
+
+## Context
+
+See [here](https://github.com/threefoldtech/tfchain/issues/924) for more details.
+
+## Decision
+
+Make sure that node has no active contracts on it to be able to change its `PowerTarget` to `Down` when calling `change_power_target()` extrinsic.

--- a/substrate-node/pallets/pallet-dao/src/mock.rs
+++ b/substrate-node/pallets/pallet-dao/src/mock.rs
@@ -17,7 +17,7 @@ use sp_runtime::{
     BuildStorage,
 };
 use sp_std::convert::{TryFrom, TryInto};
-use tfchain_support::traits::{ChangeNode, PublicIpModifier};
+use tfchain_support::traits::{ChangeNode, NodeActiveContracts, PublicIpModifier};
 use tfchain_support::types::PublicIP;
 
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
@@ -92,6 +92,13 @@ impl PublicIpModifier for PublicIpModifierType {
     fn ip_removed(_ip: &PublicIP) {}
 }
 
+pub struct NodeActiveContractsType;
+impl NodeActiveContracts for NodeActiveContractsType {
+    fn node_has_no_active_contracts(_node_id: u32) -> bool {
+        true
+    }
+}
+
 use crate::weights;
 impl pallet_dao::pallet::Config for TestRuntime {
     type RuntimeEvent = RuntimeEvent;
@@ -131,6 +138,7 @@ impl pallet_tfgrid::Config for TestRuntime {
     type WeightInfo = pallet_tfgrid::weights::SubstrateWeight<TestRuntime>;
     type NodeChanged = NodeChanged;
     type PublicIpModifier = PublicIpModifierType;
+    type NodeActiveContracts = NodeActiveContractsType;
     type TermsAndConditions = TestTermsAndConditions;
     type FarmName = TestFarmName;
     type MaxFarmNameLength = MaxFarmNameLength;

--- a/substrate-node/pallets/pallet-smart-contract/src/mock.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/mock.rs
@@ -46,7 +46,7 @@ use sp_std::{
 use std::{cell::RefCell, panic, thread};
 use tfchain_support::{
     constants::time::{MINUTES, SECS_PER_HOUR},
-    traits::{ChangeNode, PublicIpModifier},
+    traits::{ChangeNode, NodeActiveContracts, PublicIpModifier},
     types::PublicIP,
 };
 
@@ -103,7 +103,7 @@ construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
         Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-        TfgridModule: pallet_tfgrid::{Pallet, Call, Storage, Event<T>},
+        TfgridModule: pallet_tfgrid::{Pallet, Call, Storage, Event<T>, Error<T>},
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
         SmartContractModule: pallet_smart_contract::{Pallet, Call, Storage, Event<T>},
         TFTPriceModule: pallet_tft_price::{Pallet, Call, Storage, Event<T>},
@@ -192,6 +192,13 @@ impl PublicIpModifier for PublicIpModifierType {
     }
 }
 
+pub struct NodeActiveContractsType;
+impl NodeActiveContracts for NodeActiveContractsType {
+    fn node_has_no_active_contracts(node_id: u32) -> bool {
+        SmartContractModule::node_has_no_active_contracts(node_id)
+    }
+}
+
 parameter_types! {
     pub const MaxFarmNameLength: u32 = 40;
     pub const MaxInterfaceIpsLength: u32 = 5;
@@ -219,6 +226,7 @@ impl pallet_tfgrid::Config for TestRuntime {
     type WeightInfo = pallet_tfgrid::weights::SubstrateWeight<TestRuntime>;
     type NodeChanged = NodeChanged;
     type PublicIpModifier = PublicIpModifierType;
+    type NodeActiveContracts = NodeActiveContractsType;
     type TermsAndConditions = TestTermsAndConditions;
     type FarmName = TestFarmName;
     type MaxFarmNameLength = MaxFarmNameLength;

--- a/substrate-node/pallets/pallet-smart-contract/src/tests.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/tests.rs
@@ -740,6 +740,33 @@ fn test_create_rent_contract_and_switch_node_to_standby_fails() {
 }
 
 #[test]
+fn test_create_rent_contract_on_standby_node_and_wake_it_up_works() {
+    new_test_ext().execute_with(|| {
+        run_to_block(1, None);
+        prepare_dedicated_farm_and_node();
+        let node_id = 1;
+
+        assert_ok!(TfgridModule::change_power_target(
+            RuntimeOrigin::signed(alice()),
+            node_id,
+            tfchain_support::types::Power::Down,
+        ));
+
+        assert_ok!(SmartContractModule::create_rent_contract(
+            RuntimeOrigin::signed(bob()),
+            node_id,
+            None
+        ));
+
+        assert_ok!(TfgridModule::change_power_target(
+            RuntimeOrigin::signed(alice()),
+            node_id,
+            tfchain_support::types::Power::Up,
+        ));
+    });
+}
+
+#[test]
 fn test_cancel_rent_contract_works() {
     new_test_ext().execute_with(|| {
         run_to_block(1, None);

--- a/substrate-node/pallets/pallet-smart-contract/src/tests.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/tests.rs
@@ -75,6 +75,33 @@ fn test_create_node_contract_on_offline_node_fails() {
 }
 
 #[test]
+fn test_create_node_contract_and_switch_node_to_standby_fails() {
+    new_test_ext().execute_with(|| {
+        run_to_block(1, None);
+        prepare_farm_and_node();
+        let node_id = 1;
+
+        assert_ok!(SmartContractModule::create_node_contract(
+            RuntimeOrigin::signed(bob()),
+            node_id,
+            generate_deployment_hash(),
+            get_deployment_data(),
+            0,
+            None
+        ));
+
+        assert_noop!(
+            TfgridModule::change_power_target(
+                RuntimeOrigin::signed(alice()),
+                node_id,
+                tfchain_support::types::Power::Down
+            ),
+            pallet_tfgrid::Error::<TestRuntime>::NodeHasActiveContracts
+        );
+    });
+}
+
+#[test]
 fn test_create_node_contract_with_public_ips_works() {
     new_test_ext().execute_with(|| {
         run_to_block(1, None);
@@ -683,6 +710,30 @@ fn test_create_rent_contract_on_offline_node_fails() {
         assert_noop!(
             SmartContractModule::create_rent_contract(RuntimeOrigin::signed(bob()), node_id, None),
             Error::<TestRuntime>::NodeNotAvailableToDeploy
+        );
+    });
+}
+
+#[test]
+fn test_create_rent_contract_and_switch_node_to_standby_fails() {
+    new_test_ext().execute_with(|| {
+        run_to_block(1, None);
+        prepare_dedicated_farm_and_node();
+        let node_id = 1;
+
+        assert_ok!(SmartContractModule::create_rent_contract(
+            RuntimeOrigin::signed(bob()),
+            node_id,
+            None
+        ));
+
+        assert_noop!(
+            TfgridModule::change_power_target(
+                RuntimeOrigin::signed(alice()),
+                node_id,
+                tfchain_support::types::Power::Down
+            ),
+            pallet_tfgrid::Error::<TestRuntime>::NodeHasActiveContracts
         );
     });
 }

--- a/substrate-node/pallets/pallet-tfgrid/src/lib.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/lib.rs
@@ -41,7 +41,7 @@ pub mod pallet {
     use sp_std::{convert::TryInto, fmt::Debug, vec, vec::Vec};
     use tfchain_support::{
         resources::Resources,
-        traits::{ChangeNode, PublicIpModifier},
+        traits::{ChangeNode, NodeActiveContracts, PublicIpModifier},
         types::*,
     };
 
@@ -280,6 +280,8 @@ pub mod pallet {
         >;
 
         type PublicIpModifier: PublicIpModifier;
+
+        type NodeActiveContracts: NodeActiveContracts;
 
         /// The type of terms and conditions.
         type TermsAndConditions: FullCodec
@@ -567,6 +569,7 @@ pub mod pallet {
 
         InvalidPublicConfig,
         UnauthorizedToChangePowerTarget,
+        NodeHasActiveContracts,
         InvalidRelayAddress,
         InvalidTimestampHint,
     }

--- a/substrate-node/pallets/pallet-tfgrid/src/mock.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/mock.rs
@@ -20,7 +20,10 @@ use sp_runtime::{
 use sp_std::prelude::*;
 
 use hex;
-use tfchain_support::types::PublicIP;
+use tfchain_support::{
+    traits::{ChangeNode, NodeActiveContracts, PublicIpModifier},
+    types::PublicIP,
+};
 
 pub type Signature = MultiSignature;
 
@@ -79,14 +82,21 @@ pub(crate) type Interface = crate::InterfaceOf<TestRuntime>;
 pub(crate) type TfgridNode = crate::TfgridNode<TestRuntime>;
 
 pub struct NodeChanged;
-impl tfchain_support::traits::ChangeNode<Loc, Interface, Serial> for NodeChanged {
+impl ChangeNode<Loc, Interface, Serial> for NodeChanged {
     fn node_changed(_old_node: Option<&TfgridNode>, _new_node: &TfgridNode) {}
     fn node_deleted(_node: &TfgridNode) {}
 }
 
-pub struct PublicIpModifier;
-impl tfchain_support::traits::PublicIpModifier for PublicIpModifier {
+pub struct PublicIpModifierType;
+impl PublicIpModifier for PublicIpModifierType {
     fn ip_removed(_ip: &PublicIP) {}
+}
+
+pub struct NodeActiveContractsType;
+impl NodeActiveContracts for NodeActiveContractsType {
+    fn node_has_no_active_contracts(_node_id: u32) -> bool {
+        true
+    }
 }
 
 parameter_types! {
@@ -115,7 +125,8 @@ impl Config for TestRuntime {
     type RestrictedOrigin = EnsureRoot<Self::AccountId>;
     type WeightInfo = weights::SubstrateWeight<TestRuntime>;
     type NodeChanged = NodeChanged;
-    type PublicIpModifier = PublicIpModifier;
+    type PublicIpModifier = PublicIpModifierType;
+    type NodeActiveContracts = NodeActiveContractsType;
     type TermsAndConditions = TestTermsAndConditions;
     type FarmName = TestFarmName;
     type MaxFarmNameLength = MaxFarmNameLength;

--- a/substrate-node/pallets/pallet-tfgrid/src/node.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/node.rs
@@ -335,7 +335,7 @@ impl<T: Config> Pallet<T> {
 
         let mut node_power = NodePower::<T>::get(node_id);
 
-        // if the power state is different from what is set, change it and emit event
+        // If the power state is different from what is set, change it and emit event
         if node_power.state != power_state {
             node_power.state = power_state.clone();
             NodePower::<T>::insert(node_id, node_power);
@@ -368,27 +368,24 @@ impl<T: Config> Pallet<T> {
             Error::<T>::UnauthorizedToChangePowerTarget
         );
 
-        // Make sure there are no active contracts on node
+        // When power target is switched to Down, make sure there are no active contracts on node
         ensure!(
-            T::NodeActiveContracts::node_has_no_active_contracts(node_id),
+            power_target == Power::Down
+                && T::NodeActiveContracts::node_has_no_active_contracts(node_id),
             Error::<T>::NodeHasActiveContracts
         );
 
-        Self::_change_power_target_on_node(node.id, node.farm_id, power_target);
-
-        Ok(().into())
-    }
-
-    fn _change_power_target_on_node(node_id: u32, farm_id: u32, power_target: Power) {
         let mut node_power = NodePower::<T>::get(node_id);
         node_power.target = power_target.clone();
         NodePower::<T>::insert(node_id, &node_power);
 
         Self::deposit_event(Event::PowerTargetChanged {
-            farm_id,
+            farm_id: node.farm_id,
             node_id,
             power_target,
         });
+
+        Ok(().into())
     }
 
     fn get_resources(

--- a/substrate-node/pallets/pallet-tfgrid/src/node.rs
+++ b/substrate-node/pallets/pallet-tfgrid/src/node.rs
@@ -368,12 +368,13 @@ impl<T: Config> Pallet<T> {
             Error::<T>::UnauthorizedToChangePowerTarget
         );
 
-        // When power target is switched to Down, make sure there are no active contracts on node
-        ensure!(
-            power_target == Power::Down
-                && T::NodeActiveContracts::node_has_no_active_contracts(node_id),
-            Error::<T>::NodeHasActiveContracts
-        );
+        // If power target is switched to Down, make sure there are no active contracts on node
+        if power_target == Power::Down {
+            ensure!(
+                T::NodeActiveContracts::node_has_no_active_contracts(node_id),
+                Error::<T>::NodeHasActiveContracts
+            );
+        }
 
         let mut node_power = NodePower::<T>::get(node_id);
         node_power.target = power_target.clone();

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -28,7 +28,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use tfchain_support::{
     constants::time::*,
-    traits::{ChangeNode, PublicIpModifier},
+    traits::{ChangeNode, NodeActiveContracts, PublicIpModifier},
     types::PublicIP,
 };
 
@@ -339,6 +339,13 @@ impl PublicIpModifier for PublicIpModifierType {
     }
 }
 
+pub struct NodeActiveContractsType;
+impl NodeActiveContracts for NodeActiveContractsType {
+    fn node_has_no_active_contracts(node_id: u32) -> bool {
+        SmartContractModule::node_has_no_active_contracts(node_id)
+    }
+}
+
 parameter_types! {
     pub const MaxFarmNameLength: u32 = 40;
     pub const MaxInterfaceIpsLength: u32 = 10;
@@ -353,6 +360,7 @@ impl pallet_tfgrid::Config for Runtime {
     type WeightInfo = pallet_tfgrid::weights::SubstrateWeight<Runtime>;
     type NodeChanged = NodeChanged;
     type PublicIpModifier = SmartContractModule;
+    type NodeActiveContracts = NodeActiveContractsType;
     type TermsAndConditions = pallet_tfgrid::terms_cond::TermsAndConditions<Runtime>;
     type MaxFarmNameLength = MaxFarmNameLength;
     type MaxFarmPublicIps = MaxFarmPublicIps;

--- a/substrate-node/support/src/traits.rs
+++ b/substrate-node/support/src/traits.rs
@@ -14,3 +14,7 @@ pub trait ChangeNode<Loc, If, Serial> {
 pub trait PublicIpModifier {
     fn ip_removed(ip: &PublicIP);
 }
+
+pub trait NodeActiveContracts {
+    fn node_has_no_active_contracts(node_id: u32) -> bool;
+}


### PR DESCRIPTION
## Description

Make sure that node has no active contracts on it to be able to change its `PowerTarget` to `Down` when calling `change_power_target()` extrinsic.

Loose pallet coupling (see doc [here](https://docs.substrate.io/reference/how-to-guides/pallet-design/use-loose-coupling/) ) was used between `pallet-smart-contract` and `pallet-tfgrid` to avoid cyclic dependency.

## Related Issues:

- Closes #924

## Checklist:

- [x] I have added tests to cover my changes.
- [x] My commits follow this [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guide.
