### PR TITLE
uppdating tfchain values file

### DIFF
--- a/substrate-node/charts/substrate-node/values.yaml
+++ b/substrate-node/charts/substrate-node/values.yaml
@@ -49,14 +49,14 @@ is_validator: true
 
 chainspec: '/etc/chainspecs/dev/chainSpecRaw.json'
 
-rpc_max_connections: 1048576
+rpc_max_connections: "1048576"
 
 #rpc_methods: "Unsafe"
 
 rpc_methods: 'safe'
 
 # Archive will keep all history, otherwise only the last 256 blocks will be kept
-archive: true
+#archive: true
 
 # Telemetry dashboard url
 # telemetry_url: ""
@@ -76,7 +76,7 @@ global:
     certresolver: le
 
 ingress:
-  enabled: true
+  enabled: false
   annotations:
   hosts:
     - host: dev.substrate01.threefold.io


### PR DESCRIPTION
## Description

When you use Helm's -f flag to specify a custom values file, Helm combines these values with the defaults in the chart's values.yaml. The custom values will override any matching default values in the chart.
Like: [values.yaml#L52](https://github.com/threefoldtech/tfchain/blob/development/substrate-node/charts/substrate-node/values.yaml#L52) , generates error ```error: invalid value '1.048576e+06' for '--rpc-max-connections <COUNT>': invalid digit found in string``` which should be > rpc_max_connections: "1048576"

this is not fix for https://github.com/threefoldtech/tf_operations/issues/2195, but update needed for validators installation