### PR TITLE
restore the set noder certificate without sudo

### DIFF
--- a/clients/tfchain-client-go/burning.go
+++ b/clients/tfchain-client-go/burning.go
@@ -15,7 +15,7 @@ var (
 )
 
 type BurnTransaction struct {
-	Block          types.U32             `json:"block"`
+	Block          BlockNumber           `json:"block"`
 	Amount         types.U64             `json:"amount"`
 	Source         types.OptionAccountID `json:"source"`
 	Target         string                `json:"target"`

--- a/clients/tfchain-client-go/node.go
+++ b/clients/tfchain-client-go/node.go
@@ -804,3 +804,24 @@ func (s *Substrate) GetDedicatedNodePrice(nodeID uint32) (uint64, error) {
 
 	return uint64(price), nil
 }
+
+// SetNodeCertificate sets the node certificate type
+func (s *Substrate) SetNodeCertificate(identity Identity, id uint32, cert NodeCertification) error {
+	cl, meta, err := s.GetClient()
+	if err != nil {
+		return err
+	}
+
+	c, err := types.NewCall(meta, "TfgridModule.set_node_certification",
+		id, cert,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to create call")
+	}
+
+	if _, err := s.Call(cl, meta, identity, c); err != nil {
+		return errors.Wrap(err, "failed to set node certificate")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description
this PR only restore a function that was remove before. It used to use sudo but we don't need sudo for it anymore but we still need the function
