### PR TITLE
fix(pallet-smart-contract): discount level calculation

### DIFF
--- a/substrate-node/Cargo.lock
+++ b/substrate-node/Cargo.lock
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fde6067df7359f2d6335ec1a50c1f8f825801687d10da0cc4c6b08e3f6afd15"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -7035,9 +7035,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
+checksum = "3b187f0231d56fe41bfb12034819dd2bf336422a5866de41bc3fec4b2e3883e8"
 
 [[package]]
 name = "snap"

--- a/substrate-node/pallets/pallet-smart-contract/src/benchmarking.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/benchmarking.rs
@@ -305,7 +305,7 @@ benchmarks! {
 
         let contract = SmartContractModule::<T>::contracts(contract_id).unwrap();
         // Get contract cost before billing to take into account nu
-        let (cost, _) = contract.calculate_contract_cost_tft(balance_init_amount, elapsed_seconds).unwrap();
+        let (cost, discount_level) = contract.calculate_contract_cost_tft(balance_init_amount, elapsed_seconds).unwrap();
     }: _(RawOrigin::Signed(farmer), contract_id)
     verify {
         let lock = SmartContractModule::<T>::contract_number_of_cylces_billed(contract_id);
@@ -313,7 +313,7 @@ benchmarks! {
         let contract_bill = types::ContractBill {
             contract_id,
             timestamp: SmartContractModule::<T>::get_current_timestamp_in_secs(),
-            discount_level: types::DiscountLevel::Gold,
+            discount_level,
             amount_billed: cost.saturated_into::<u128>(),
         };
         assert_last_event::<T>(Event::ContractBilled(contract_bill).into());

--- a/substrate-node/pallets/pallet-smart-contract/src/cost.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/cost.rs
@@ -305,8 +305,9 @@ pub fn calculate_discount_tft<T: Config>(
 
     // calculate amount due on a monthly basis
     // first get the normalized amount per hour
-    let amount_due_hourly = U64F64::from_num(amount_due) * U64F64::from_num(seconds_elapsed)
-        / U64F64::from_num(SECS_PER_HOUR);
+    // amount_due / seconds_elapsed = amount_due_hourly / 3600
+    let amount_due_hourly = U64F64::from_num(amount_due) * U64F64::from_num(SECS_PER_HOUR)
+        / U64F64::from_num(seconds_elapsed);
     // then we can infer the amount due monthly (30 days ish)
     let amount_due_monthly = (amount_due_hourly * 24 * 30).round().to_num::<u64>();
 

--- a/substrate-node/pallets/pallet-smart-contract/src/tests.rs
+++ b/substrate-node/pallets/pallet-smart-contract/src/tests.rs
@@ -1765,7 +1765,7 @@ fn test_name_contract_billing() {
         let twin = TfgridModule::twins(twin_id).unwrap();
         let balance = Balances::free_balance(&twin.account_id);
         let second_elapsed = BillingFrequency::get() * SECS_PER_BLOCK;
-        let (contract_cost, _) = contract
+        let (contract_cost, discount_level) = contract
             .calculate_contract_cost_tft(balance, second_elapsed)
             .unwrap();
 
@@ -1773,7 +1773,7 @@ fn test_name_contract_billing() {
         let contract_bill_event = types::ContractBill {
             contract_id,
             timestamp: 1628082066,
-            discount_level: types::DiscountLevel::Gold,
+            discount_level,
             amount_billed: contract_cost as u128,
         };
 


### PR DESCRIPTION
## Description

Error in discount level calculation. Elapsed time was taken into account but in a wrong way. We should use `amount_due / seconds_elapsed = amount_due_hourly / 3600` formula.

## Related Issues:

- Fixes #940

## Checklist

- [x] I have added tests to cover my changes.
- [x] My commits follow this [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guide.
