### PR TITLE
Fix interface is nil not string error

### DIFF
--- a/bridge/tfchain_bridge/pkg/bridge/refund.go
+++ b/bridge/tfchain_bridge/pkg/bridge/refund.go
@@ -56,7 +56,7 @@ func (bridge *Bridge) handleRefundExpired(ctx context.Context, refundExpiredEven
 	if err != nil {
 		return err
 	}
-	
+
 	reason := _logger.GetRefundReason(ctx)
 	logger.Info().
 		Str("event_action", "refund_proposed").

--- a/bridge/tfchain_bridge/pkg/bridge/refund.go
+++ b/bridge/tfchain_bridge/pkg/bridge/refund.go
@@ -2,7 +2,6 @@ package bridge
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -57,8 +56,8 @@ func (bridge *Bridge) handleRefundExpired(ctx context.Context, refundExpiredEven
 	if err != nil {
 		return err
 	}
-
-	reason := fmt.Sprint(_logger.GetRefundReason(ctx))
+	
+	reason := _logger.GetRefundReason(ctx)
 	logger.Info().
 		Str("event_action", "refund_proposed").
 		Str("event_kind", "event").

--- a/bridge/tfchain_bridge/pkg/logger/logger.go
+++ b/bridge/tfchain_bridge/pkg/logger/logger.go
@@ -35,7 +35,11 @@ func WithRefundReason(ctx context.Context, reason string) context.Context {
 }
 
 func GetRefundReason(ctx context.Context) string {
-	return ctx.Value(refundReasonKey{}).(string)
+	reason := ctx.Value(refundReasonKey{})
+	if reason == nil {
+		return ""
+	}
+	return reason.(string)
 }
 
 // TODO: event log interfaces


### PR DESCRIPTION
## Description

Handle the case where the refund reason value is not available in the context.
The refund reason would be available on the context of the first refund attempt.

## Related Issues:
https://github.com/threefoldtech/tfchain/issues/936
