### PR TITLE
chore: bump to version 2.7.0-rc4 (specVersion: 149)

### DIFF
--- a/activation-service/helm/tfchainactivationservice/Chart.yaml
+++ b/activation-service/helm/tfchainactivationservice/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tfchainactivationservice
 description: TFchain account activation funding service
 type: application
-version: 2.7.0-rc3
-appVersion: '2.7.0-rc3'
+version: 2.7.0-rc4
+appVersion: '2.7.0-rc4'

--- a/activation-service/package.json
+++ b/activation-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "substrate-funding-service",
-  "version": "2.7.0-rc3",
+  "version": "2.7.0-rc4",
   "description": "Substrate funding service",
   "main": "index.js",
   "scripts": {

--- a/bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml
+++ b/bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tfchainbridge
 description: Bridge for TFT between Tfchain Stellar
 type: application
-version: 2.7.0-rc3
-appVersion: '2.7.0-rc3'
+version: 2.7.0-rc4
+appVersion: '2.7.0-rc4'

--- a/clients/tfchain-client-js/package.json
+++ b/clients/tfchain-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfgrid-api-client",
-  "version": "2.7.0-rc3",
+  "version": "2.7.0-rc4",
   "description": "API client for the TF Grid",
   "main": "index.js",
   "scripts": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfchain-js-scripts",
-  "version": "2.7.0-rc3",
+  "version": "2.7.0-rc4",
   "description": "scripts to fetch data / write data to tfchain",
   "main": "index.js",
   "scripts": {

--- a/substrate-node/Cargo.lock
+++ b/substrate-node/Cargo.lock
@@ -4244,7 +4244,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-burning"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-dao"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -4325,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-kvstore"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-runtime-upgrade"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-smart-contract"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -4477,7 +4477,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-tfgrid"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 dependencies = [
  "env_logger",
  "frame-benchmarking",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-tft-bridge"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4523,7 +4523,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-tft-price"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4627,7 +4627,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-validator"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7996,7 +7996,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-validator-set"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8134,7 +8134,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tfchain"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 dependencies = [
  "clap",
  "frame-benchmarking",
@@ -8180,7 +8180,7 @@ dependencies = [
 
 [[package]]
 name = "tfchain-runtime"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -8234,7 +8234,7 @@ dependencies = [
 
 [[package]]
 name = "tfchain-support"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/substrate-node/Cargo.toml
+++ b/substrate-node/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://threefold.io/"
 license-file = "LICENSE"
 readme = "README.md"
 repository = "https://github.com/threefoldtech/tfchain3"
-version = "2.7.0-rc3"
+version = "2.7.0-rc4"
 
 [workspace]
 members = [

--- a/substrate-node/charts/substrate-node/Chart.yaml
+++ b/substrate-node/charts/substrate-node/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: substrate-node
 description: Tfchain node
 type: application
-version: 2.7.0-rc3
-appVersion: '2.7.0-rc3'
+version: 2.7.0-rc4
+appVersion: '2.7.0-rc4'

--- a/substrate-node/runtime/src/lib.rs
+++ b/substrate-node/runtime/src/lib.rs
@@ -151,7 +151,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("substrate-threefold"),
     impl_name: create_runtime_str!("substrate-threefold"),
     authoring_version: 1,
-    spec_version: 148,
+    spec_version: 149,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/tools/fork-off-substrate/package.json
+++ b/tools/fork-off-substrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-off-substrate",
-  "version": "2.7.0-rc3",
+  "version": "2.7.0-rc4",
   "description": "This script allows bootstrapping a new substrate chain with the current state of a live chain",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Description

- bump to version `2.7.0-rc4` and retain specVersion: `149`
