### PR TITLE
Add makefile version-bump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+.PHONY: version-bump
+
+# usage: > type=patch make version-bump
+# usage: > type=minor make version-bump
+# usage: > type=major make version-bump
+version-bump:
+	set -e; \
+	if [ "$(type)" = "patch" ] || [ "$(type)" = "minor" ] || [ "$(type)" = "major" ]; then \
+		default_branch=$$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'); \
+		git checkout $$default_branch; \
+		git pull origin $$default_branch; \
+		new_version=$$(npx semver -i $(type) $$(jq -r .version clients/tfchain-client-js/package.json)); \
+		branch_name="$$default_branch-bump-version-to-$$new_version"; \
+		git checkout -b $$branch_name; \
+		current_spec_version=$$(sed -n -e 's/^.*spec_version: \([0-9]\+\),$$/\1/p' substrate-node/runtime/src/lib.rs); \
+		echo "Current spec_version: $$current_spec_version"; \
+		new_spec_version=$$((current_spec_version + 1)); \
+		echo "New spec_version: $$new_spec_version"; \
+		sed -i "s/spec_version: $$current_spec_version,/spec_version: $$new_spec_version,/" substrate-node/runtime/src/lib.rs; \
+		jq ".version = \"$$new_version\"" activation-service/package.json > temp.json && mv temp.json activation-service/package.json; \
+		jq ".version = \"$$new_version\"" clients/tfchain-client-js/package.json > temp.json && mv temp.json clients/tfchain-client-js/package.json; \
+		jq ".version = \"$$new_version\"" scripts/package.json > temp.json && mv temp.json scripts/package.json; \
+		jq ".version = \"$$new_version\"" tools/fork-off-substrate/package.json > temp.json && mv temp.json tools/fork-off-substrate/package.json; \
+		sed -i "s/^version = .*/version = \"$$new_version\"/" substrate-node/Cargo.toml; \
+		sed -i "s/^version: .*/version: $$new_version/" substrate-node/charts/substrate-node/Chart.yaml; \
+		sed -i "s/^appVersion: .*/appVersion: '$$new_version'/" substrate-node/charts/substrate-node/Chart.yaml; \
+		sed -i "s/^version: .*/version: $$new_version/" bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml; \
+		sed -i "s/^appVersion: .*/appVersion: '$$new_version'/" bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml; \
+		sed -i "s/^version: .*/version: $$new_version/" activation-service/helm/tfchainactivationservice/Chart.yaml; \
+		sed -i "s/^appVersion: .*/appVersion: '$$new_version'/" activation-service/helm/tfchainactivationservice/Chart.yaml; \
+		cd substrate-node && cargo metadata -q 1> /dev/null && cd ..; \
+		git add substrate-node/Cargo.toml substrate-node/Cargo.lock substrate-node/charts/substrate-node/Chart.yaml bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml activation-service/helm/tfchainactivationservice/Chart.yaml activation-service/package.json clients/tfchain-client-js/package.json scripts/package.json tools/fork-off-substrate/package.json substrate-node/runtime/src/lib.rs; \
+		git commit -m "Bump version to $$new_version"; \
+	else \
+		echo "Invalid version type. Please use patch, minor, or major."; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ version-bump:
 		sed -i "s/^appVersion: .*/appVersion: '$$new_version'/" activation-service/helm/tfchainactivationservice/Chart.yaml; \
 		cd substrate-node && cargo metadata -q 1> /dev/null && cd ..; \
 		git add substrate-node/Cargo.toml substrate-node/Cargo.lock substrate-node/charts/substrate-node/Chart.yaml bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml activation-service/helm/tfchainactivationservice/Chart.yaml activation-service/package.json clients/tfchain-client-js/package.json scripts/package.json tools/fork-off-substrate/package.json substrate-node/runtime/src/lib.rs; \
-		git commit -m "Bump version to $$new_version (spec $$new_spec_version)"; \
+		git commit -m "Bump version to $$new_version (spec v$$new_spec_version)"; \
 	else \
 		echo "Invalid version type. Please use patch, minor, or major."; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ version-bump:
 		sed -i "s/^appVersion: .*/appVersion: '$$new_version'/" activation-service/helm/tfchainactivationservice/Chart.yaml; \
 		cd substrate-node && cargo metadata -q 1> /dev/null && cd ..; \
 		git add substrate-node/Cargo.toml substrate-node/Cargo.lock substrate-node/charts/substrate-node/Chart.yaml bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml activation-service/helm/tfchainactivationservice/Chart.yaml activation-service/package.json clients/tfchain-client-js/package.json scripts/package.json tools/fork-off-substrate/package.json substrate-node/runtime/src/lib.rs; \
-		git commit -m "Bump version to $$new_version"; \
+		git commit -m "Bump version to $$new_version (spec $$new_spec_version)"; \
 	else \
 		echo "Invalid version type. Please use patch, minor, or major."; \
 	fi

--- a/docs/production/releases.md
+++ b/docs/production/releases.md
@@ -20,6 +20,8 @@ type=major make version-bump # incrment the major version
 
 This function will take care also of branch and commit creation. Review the changes and push them, then follow the steps 3 and 4 below to finish the release.
 
+Important: This function will also incrment the spec version in the runtime. If you already did this in another commit you need to undo spec_version changes to avoid double incrment.
+
 ### Manually
 
 1 - create the a new branch for the release. increment the version for all components in the monorepo. here is a list of the files that need to be changed to make the release:

--- a/docs/production/releases.md
+++ b/docs/production/releases.md
@@ -1,38 +1,60 @@
-## Releases
+# Releases
 
 Releases are automated by [this workflow](.github/workflows/030_create_release.yaml). When a release should be created following things need to be done:
 
-*   substrate-node
-    *   Increment spec version in the runtime [lib.rs](../../substrate-node/runtime/src/lib.rs)
-    *   Increment version in [Cargo.toml](../../substrate-node/Cargo.toml)
-    *   Increment chart `version` filed in [Chart.yaml](../../substrate-node/charts/substrate-node/Chart.yaml)
-    *   Increment chart `appVersion` filed in [Chart.yaml](../../substrate-node/charts/substrate-node/Chart.yaml)
+## Version bump
 
-*   tfchainbridge
-    *   Increment chart `version` filed in [Chart.yaml](../../bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
-    *   Increment chart `appVersion` filed in [Chart.yaml](../../bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
+This step can be done using Makefile or manually.
 
-*   activation-service
-    *   Increment chart `version` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
-    *   Increment chart `appVersion` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
-    *   Increment package `version` in [package.json](../../activation-service/package.json)
+### Makefile
 
-*   Js TFChain Client
-    *   Increment package `version` in [package.json](../../clients/tfchain-client-js/package.json)
+see makefile [here](../../Makefile)
 
-*   Scripts
-    *   Increment package `version` in [package.json](../../scripts/package.json)
+#### Usage
 
-*   Tools/fork-off-substrate
-    *   Increment package `version` in [package.json](../../tools/fork-off-substrate/package.json)
+```bash
+type=patch make version-bump # incrment the patch version
+type=minor make version-bump # incrment the minor version
+type=major make version-bump # incrment the major version
+```
 
-*   Commit the changes
+This function will take care also of branch and commit creation. Review the changes and push them, then follow the steps 3 and 4 below to finish the release.
 
-*   Create a new tag with the version number prefixed with a `v` (e.g. `v1.0.0`, `v1.0.0-rc1` for release candidates)
+### Manually
 
-*   Push the tag to the repository
+1 - create the a new branch for the release. increment the version for all components in the monorepo. here is a list of the files that need to be changed to make the release:
 
-*   The workflow will create a release draft with the changelog and the binaries attached
+* substrate-node
+  * Increment spec version in the runtime [lib.rs](../../substrate-node/runtime/src/lib.rs)
+  * Increment version in [Cargo.toml](../../substrate-node/Cargo.toml)
+  * Increment chart `version` filed in [Chart.yaml](../../substrate-node/charts/substrate-node/Chart.yaml)
+  * Increment chart `appVersion` filed in [Chart.yaml](../../substrate-node/charts/substrate-node/Chart.yaml)
+
+* tfchainbridge
+  * Increment chart `version` filed in [Chart.yaml](../../bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
+  * Increment chart `appVersion` filed in [Chart.yaml](../../bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml)
+
+* activation-service
+  * Increment chart `version` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
+  * Increment chart `appVersion` filed in [Chart.yaml](../../activation-service/helm/tfchainactivationservice/Chart.yaml)
+  * Increment package `version` in [package.json](../../activation-service/package.json)
+
+* Js TFChain Client
+  * Increment package `version` in [package.json](../../clients/tfchain-client-js/package.json)
+
+* Scripts
+  * Increment package `version` in [package.json](../../scripts/package.json)
+
+* Tools/fork-off-substrate
+  * Increment package `version` in [package.json](../../tools/fork-off-substrate/package.json)
+
+2 - Commit the changes
+
+3 - Create a new tag with the version number prefixed with a `v` (e.g. `v1.0.0`)
+
+4 - Push the tag to the repository
+
+The workflow will create a release draft with the changelog and the binaries attached
 
 A changelog will be generated based on the Pull requests merged, so having PRs with meaningful titles is important.
 
@@ -40,7 +62,7 @@ A changelog will be generated based on the Pull requests merged, so having PRs w
 
 See [validate](../misc/validating_runtime.md) for instructions on how to validate a runtime.
 
-### Upgrade runtime
+## Upgrade runtime
 
 To upgrade the runtime for a network based on a release, download the runtime attached to the release (tfchain\_runtime.compact.compressed.wasm)
 and upload it to the network using a council proposal. The proposal should be a `set_code` proposal with the runtime as the code and majority of the council should vote in favor of the proposal.

--- a/docs/production/releases.md
+++ b/docs/production/releases.md
@@ -18,13 +18,16 @@ type=minor make version-bump # incrment the minor version
 type=major make version-bump # incrment the major version
 ```
 
-This function will take care also of branch and commit creation. Review the changes and push them, then follow the steps 3 and 4 below to finish the release.
+This function will take care also of branch and commit creation.
+Review the changes and push them, then follow the steps 3 and 4 below to finish the release.
 
-Important: This function will also incrment the spec version in the runtime. If you already did this in another commit you need to undo spec_version changes to avoid double incrment.
+Important: This function will also incrment the spec version in the runtime.
+If you already did this in another commit you need to undo spec_version changes to avoid double incrment.
 
 ### Manually
 
-1 - create the a new branch for the release. increment the version for all components in the monorepo. here is a list of the files that need to be changed to make the release:
+1 - Create a new branch for the release, increment the version for all components in the monorepo.
+Here is a list of the files that need to be changed to make the release:
 
 * substrate-node
   * Increment spec version in the runtime [lib.rs](../../substrate-node/runtime/src/lib.rs)
@@ -58,7 +61,7 @@ Important: This function will also incrment the spec version in the runtime. If 
 
 The workflow will create a release draft with the changelog and the binaries attached
 
-A changelog will be generated based on the Pull requests merged, so having PRs with meaningful titles is important.
+The generated changelog will be based on the merged Pull requests, so having PRs with meaningful titles is important.
 
 ## Validate a runtime
 
@@ -66,5 +69,5 @@ See [validate](../misc/validating_runtime.md) for instructions on how to validat
 
 ## Upgrade runtime
 
-To upgrade the runtime for a network based on a release, download the runtime attached to the release (tfchain\_runtime.compact.compressed.wasm)
-and upload it to the network using a council proposal. The proposal should be a `set_code` proposal with the runtime as the code and majority of the council should vote in favor of the proposal.
+To upgrade the runtime for a network based on a release, download the runtime attached to the release (tfchain\_runtime.compact.compressed.wasm) and upload it to the network using a council proposal.
+The proposal should be a `set_code` proposal with the runtime as the code and majority of the council should vote in favor of the proposal.

--- a/docs/production/releases.md
+++ b/docs/production/releases.md
@@ -1,6 +1,7 @@
 # Releases
 
-Releases are automated by [this workflow](.github/workflows/030_create_release.yaml). When a release should be created following things need to be done:
+Releases are automated by [this workflow](.github/workflows/030_create_release.yaml).
+When a release should be created following things need to be done:
 
 ## Version bump
 


### PR DESCRIPTION
## Description

This PR add Makefile with a version-bump function that automate the version incrementing within the repo files.
```
# usage: > type=patch|minor|major make version-bump
```

it will also create the branch, the commit, and increment the spec_version and all other files mentioned in the release doc

## Related Issues:
https://github.com/threefoldtech/tfchain/issues/975

