### PR TITLE
Allow spec_version increment skipping during version-bump execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 .PHONY: version-bump
 
-# usage: > type=patch make version-bump
-# usage: > type=minor make version-bump
-# usage: > type=major make version-bump
+# * Usage Examples:*
+# type=patch make version-bump
+# type=minor make version-bump
+# type=major make version-bump
+# ** skip increment spce_version in substrate-node/runtime/src/lib.rs **
+# type=patch retain_spec_version=1 make version-bump
 version-bump:
 	set -e; \
 	if [ "$(type)" = "patch" ] || [ "$(type)" = "minor" ] || [ "$(type)" = "major" ]; then \
@@ -13,10 +16,13 @@ version-bump:
 		branch_name="$$default_branch-bump-version-to-$$new_version"; \
 		git checkout -b $$branch_name; \
 		current_spec_version=$$(sed -n -e 's/^.*spec_version: \([0-9]\+\),$$/\1/p' substrate-node/runtime/src/lib.rs); \
-		echo "Current spec_version: $$current_spec_version"; \
-		new_spec_version=$$((current_spec_version + 1)); \
-		echo "New spec_version: $$new_spec_version"; \
-		sed -i "s/spec_version: $$current_spec_version,/spec_version: $$new_spec_version,/" substrate-node/runtime/src/lib.rs; \
+		if [ -z "$${retain_spec_version}" ]; then \
+			current_spec_version=$$(sed -n -e 's/^.*spec_version: \([0-9]\+\),$$/\1/p' substrate-node/runtime/src/lib.rs); \
+			echo "Current spec_version: $$current_spec_version"; \
+			new_spec_version=$$((current_spec_version + 1)); \
+			echo "New spec_version: $$new_spec_version"; \
+			sed -i "s/spec_version: $$current_spec_version,/spec_version: $$new_spec_version,/" substrate-node/runtime/src/lib.rs; \
+		fi; \
 		jq ".version = \"$$new_version\"" activation-service/package.json > temp.json && mv temp.json activation-service/package.json; \
 		jq ".version = \"$$new_version\"" clients/tfchain-client-js/package.json > temp.json && mv temp.json clients/tfchain-client-js/package.json; \
 		jq ".version = \"$$new_version\"" scripts/package.json > temp.json && mv temp.json scripts/package.json; \
@@ -34,3 +40,4 @@ version-bump:
 	else \
 		echo "Invalid version type. Please use patch, minor, or major."; \
 	fi
+

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # type=patch make version-bump
 # type=minor make version-bump
 # type=major make version-bump
-# ** skip increment spce_version in substrate-node/runtime/src/lib.rs **
+# ** skip increment spec_version in substrate-node/runtime/src/lib.rs **
 # type=patch retain_spec_version=1 make version-bump
 version-bump:
 	set -e; \

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,11 @@ version-bump:
 		sed -i "s/^appVersion: .*/appVersion: '$$new_version'/" activation-service/helm/tfchainactivationservice/Chart.yaml; \
 		cd substrate-node && cargo metadata -q 1> /dev/null && cd ..; \
 		git add substrate-node/Cargo.toml substrate-node/Cargo.lock substrate-node/charts/substrate-node/Chart.yaml bridge/tfchain_bridge/chart/tfchainbridge/Chart.yaml activation-service/helm/tfchainactivationservice/Chart.yaml activation-service/package.json clients/tfchain-client-js/package.json scripts/package.json tools/fork-off-substrate/package.json substrate-node/runtime/src/lib.rs; \
-		git commit -m "Bump version to $$new_version (spec v$$new_spec_version)"; \
+		if [ -z "$${new_spec_version}" ]; then \
+			git commit -m "Bump version to $$new_version"; \
+		else \
+			git commit -m "Bump version to $$new_version (spec v$$new_spec_version)"; \
+		fi \
 	else \
 		echo "Invalid version type. Please use patch, minor, or major."; \
 	fi
-

--- a/docs/production/releases.md
+++ b/docs/production/releases.md
@@ -23,7 +23,11 @@ This function will take care also of branch and commit creation.
 Review the changes and push them, then follow the steps 3 and 4 below to finish the release.
 
 Important: This function will also incrment the spec version in the runtime.
-If you already did this in another commit you need to undo spec_version changes to avoid double incrment.
+If you already did this in another commit or you don't need to do this, you can instruct the Makefile version-bump function to skip it by setting the `retain_spec_version` variable to 1 or any other value.
+
+```bash
+type=patch retain_spec_version=1 make version-bump
+```
 
 ### Manually
 


### PR DESCRIPTION
## Description

allow increment spec_version skipping in substrate-node/runtime/src/lib.rs during version-bump execution

Usage:

```bash
type=patch retain_spec_version=1 make version-bump
```

It is needed if you want to bump the version to release non-runtime related changes like in bridge, activation services, etc.