### PR TITLE
Define separate error types for activation service errors

### DIFF
--- a/clients/tfchain-client-go/account.go
+++ b/clients/tfchain-client-go/account.go
@@ -52,6 +52,14 @@ type AccountInfo struct {
 	Data        Balance   `json:"data"`
 }
 
+type ActivationServiceError struct {
+	Err error
+}
+
+func (e ActivationServiceError) Error() string {
+	return fmt.Sprintf("Activation service error: %s", e.Err.Error())
+}
+
 // PublicKey gets public key from account id
 func (a AccountID) PublicKey() []byte {
 	return a[:]
@@ -135,7 +143,7 @@ func (s *Substrate) activateAccount(identity Identity, activationURL string) err
 
 	response, err := http.Post(activationURL, "application/json", &buf)
 	if err != nil {
-		return errors.Wrap(err, "failed to call activation service")
+		return ActivationServiceError{Err: errors.Wrap(err, "failed to call activation service")}
 	}
 
 	defer response.Body.Close()
@@ -145,22 +153,22 @@ func (s *Substrate) activateAccount(identity Identity, activationURL string) err
 		return nil
 	}
 
-	return fmt.Errorf("failed to activate account: %s", response.Status)
+	return ActivationServiceError{Err: fmt.Errorf("failed to activate account: %s", response.Status)}
 }
 
 // EnsureAccount makes sure account is available on blockchain
 // if not, it uses activation service to create one.
 // EnsureAccount is safe to call on already activated accounts and it's mostly
 // a NO-OP operation unless the account funds are very low, it will then make
-// sure to reactivate the account (fund it) if the free tokes are <= ReactivateThreefold uTFT
-func (s *Substrate) EnsureAccount(identity Identity, activationURL, termsAndConditionsLink, terminsAndConditionsHash string) (info AccountInfo, err error) {
+// sure to reactivate the account (fund it) if the free tokens are <= ReactivateThreefold uTFT
+func (s *Substrate) EnsureAccount(identity Identity, activationURL, termsAndConditionsLink, termsAndConditionsHash string) (info AccountInfo, err error) {
 	log.Debug().Str("account", identity.Address()).Msg("ensuring account")
 	cl, meta, err := s.GetClient()
 	if err != nil {
 		return info, err
 	}
 	info, err = s.getAccount(cl, meta, identity)
-	// if account does not exist OR account has tokes less that reactivateAt
+	// if account does not exist OR account has tokens less than reactivateAt
 	// then we activate the account.
 	if errors.Is(err, ErrAccountNotFound) || info.Data.Free.Cmp(reactivateAt) <= 0 {
 		// account activation
@@ -203,7 +211,7 @@ func (s *Substrate) EnsureAccount(identity Identity, activationURL, termsAndCond
 		return info, nil
 	}
 
-	return info, s.AcceptTermsAndConditions(identity, termsAndConditionsLink, terminsAndConditionsHash)
+	return info, s.AcceptTermsAndConditions(identity, termsAndConditionsLink, termsAndConditionsHash)
 }
 
 // Identity is a user identity

--- a/clients/tfchain-client-go/account.go
+++ b/clients/tfchain-client-go/account.go
@@ -52,11 +52,16 @@ type AccountInfo struct {
 	Data        Balance   `json:"data"`
 }
 
+// TODO: Add service response status code if avialble
 type ActivationServiceError struct {
-	Err error
+	StatusCode int // 0 or a valid HTTP status code. 0 indicates that a response was not recived due to an error such host unreachable.
+	Err        error
 }
 
 func (e ActivationServiceError) Error() string {
+	if e.StatusCode != 0 {
+		return fmt.Sprintf("Activation service error (status code %d): %s", e.StatusCode, e.Err.Error())
+	}
 	return fmt.Sprintf("Activation service error: %s", e.Err.Error())
 }
 
@@ -153,7 +158,7 @@ func (s *Substrate) activateAccount(identity Identity, activationURL string) err
 		return nil
 	}
 
-	return ActivationServiceError{Err: fmt.Errorf("failed to activate account: %s", response.Status)}
+	return ActivationServiceError{StatusCode: response.StatusCode, Err: fmt.Errorf("activation service returned status code %d", response.StatusCode)}
 }
 
 // EnsureAccount makes sure account is available on blockchain

--- a/clients/tfchain-client-go/account_test.go
+++ b/clients/tfchain-client-go/account_test.go
@@ -40,3 +40,18 @@ func TestGetBalance(t *testing.T) {
 	_, err = cl.GetBalance(account)
 	require.NoError(err)
 }
+
+func TestEnsureAccount_WithDownActivationService(t *testing.T) {
+	cl := startLocalConnection(t)
+	defer cl.Close()
+
+	require := require.New(t)
+	id, err := NewIdentityFromEd25519Phrase("paper endless radio rude wage hood cabin praise girl income chief craft")
+	require.NoError(err)
+	_, err = cl.EnsureAccount(id, "https://test.wrong-activation-service-url.tf", "test", "test")
+	require.Error(err)
+	require.IsType(ActivationServiceError{}, err)
+	_, err = cl.EnsureAccount(id, "https://httpstat.us/503", "test", "test")
+	require.Error(err)
+	require.IsType(ActivationServiceError{}, err)
+}

--- a/clients/tfchain-client-go/account_test.go
+++ b/clients/tfchain-client-go/account_test.go
@@ -41,7 +41,7 @@ func TestGetBalance(t *testing.T) {
 	require.NoError(err)
 }
 
-func TestEnsureAccount_WithDownActivationService(t *testing.T) {
+func TestEnsureAccountWithDownActivationService(t *testing.T) {
 	cl := startLocalConnection(t)
 	defer cl.Close()
 


### PR DESCRIPTION
## Description
EnsureAccount method now returns a custom error type `ActivationServiceError` for activation service-related errors.
This allows for easily identifying the source of the error by checking the type of error returned.

for example:

```go
info, err := s.EnsureAccount(identity, activationURL, termsAndConditionsLink, terminsAndConditionsHash)
if err != nil {
    switch errType := err.(type) {
    case ActivationServiceError:
        // Handle Activation Service error
        fmt.Println("Activation service error:", errType.Err)
    default:
        // Handle other error types
        fmt.Println("Substrate error:", err)
    }
}
```

## Related Issues:

- #985 

## Checklist:

- [X] I have added tests to cover my changes.
- [X] My commits follow this [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guide.
