### PR TITLE
Pin Srtool version to 1.77.0 for compatibility

### DIFF
--- a/.github/workflows/030_create_release.yaml
+++ b/.github/workflows/030_create_release.yaml
@@ -28,6 +28,7 @@ jobs:
           workdir: '${{ github.workspace }}/substrate-node'
           package: tfchain-runtime
           runtime_dir: runtime
+          tag: "1.77.0"
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Description

The latest Srtool version (1.81.0) uses rustc 1.81.0, which causes issues with our current setup. TFChain and polkadot-sdk 1.1.0 are tested with rustc 1.70.0. This commit pins Srtool to version 1.77.0 to avoid compatibility issues until we can update to the latest polkadot-sdk.

## Related Issues:

https://github.com/threefoldtech/tfchain/issues/1014

## Checklist:

- [X] My commits follow this [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guide.
