### PR TITLE
Handle retry mechanism and low balance refunding

### DIFF
--- a/bridge/tfchain_bridge/go.mod
+++ b/bridge/tfchain_bridge/go.mod
@@ -21,6 +21,7 @@ require (
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3
+	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20230607082553-5605bca61c79
 )
 
@@ -39,6 +40,7 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/gtank/merlin v0.1.1 // indirect
 	github.com/gtank/ristretto255 v0.1.2 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/jbenet/go-base58 v0.0.0-20150317085156-6237cf65f3a6 // indirect
 	github.com/manucorporat/sse v0.0.0-20160126180136-ee05b128a739 // indirect
 	github.com/mimoo/StrobeGo v0.0.0-20220103164710-9a04d6ca976b // indirect
@@ -50,7 +52,7 @@ require (
 	github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a // indirect
 	github.com/stretchr/testify v1.7.2 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/sys v0.20.0 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/bridge/tfchain_bridge/go.sum
+++ b/bridge/tfchain_bridge/go.sum
@@ -101,6 +101,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum/go-ethereum v1.10.20 h1:75IW830ClSS40yrQC1ZCMZCt5I+zU16oqId2SiQwdQ4=
 github.com/ethereum/go-ethereum v1.10.20/go.mod h1:LWUN82TCHGpxB3En5HVmLLzPD7YSrEUFmFfN1nKkVN0=
+github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
+github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/fatih/structs v1.0.0 h1:BrX964Rv5uQ3wwS+KRUAJCBBw5PQmgJfJ6v4yly5QwU=
 github.com/fatih/structs v1.0.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -208,6 +210,12 @@ github.com/gtank/merlin v0.1.1/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/b
 github.com/gtank/ristretto255 v0.1.2 h1:JEqUCPA1NvLq5DwYtuzigd7ss8fwbYay9fi4/5uMzcc=
 github.com/gtank/ristretto255 v0.1.2/go.mod h1:Ph5OpO6c7xKUGROZfWVLiJf9icMDwUeIvY4OmlYW69o=
 github.com/guregu/null v2.1.3-0.20151024101046-79c5bd36b615+incompatible/go.mod h1:ePGpQaN9cw0tj45IR5E5ehMvsFlLlQZAkkOXZurJ3NM=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
+github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
+github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
@@ -254,7 +262,11 @@ github.com/magiconair/properties v1.5.4/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/manucorporat/sse v0.0.0-20160126180136-ee05b128a739 h1:ykXz+pRRTibcSjG1yRhpdSHInF8yZY/mfn+Rz2Nd1rE=
 github.com/manucorporat/sse v0.0.0-20160126180136-ee05b128a739/go.mod h1:zUx1mhth20V3VKgL5jbd1BSQcW4Fy6Qs4PZvQwRFwzM=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643/go.mod h1:43+3pMjjKimDBf5Kr4ZFNGbLql1zKkbImw+fZbw3geM=
@@ -540,8 +552,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/bridge/tfchain_bridge/pkg/bridge/refund.go
+++ b/bridge/tfchain_bridge/pkg/bridge/refund.go
@@ -14,28 +14,6 @@ import (
 
 // refund handler for stellar
 func (bridge *Bridge) refund(ctx context.Context, destination string, amount int64, tx hProtocol.Transaction) error {
-	if amount <= bridge.depositFee {
-		logger := log.Logger.With().Str("trace_id", tx.ID).Logger()
-
-		logger.Info().
-			Str("event_action", "refund_dropped").
-			Str("event_kind", "event").
-			Str("category", "refund").
-			Dict("metadata", zerolog.Dict().
-				Int64("amount", amount).
-				Int64("min_required", bridge.depositFee)).
-			Msg("refund dropped due to amount being less than or equal to deposit fee")
-
-		// save cursor
-		cursor := tx.PagingToken()
-		err := bridge.blockPersistency.SaveStellarCursor(cursor)
-		if err != nil {
-			return errors.Wrap(err, "an error occurred while saving stellar cursor")
-		}
-
-		return nil
-	}
-
 	err := bridge.handleRefundExpired(ctx, subpkg.RefundTransactionExpiredEvent{
 		Hash:   tx.Hash,
 		Amount: uint64(amount),
@@ -68,23 +46,6 @@ func (bridge *Bridge) handleRefundExpired(ctx context.Context, refundExpiredEven
 			Msg("the transaction has already been refunded")
 		return nil
 	}
-
-    if refundExpiredEvent.Amount <= uint64(bridge.depositFee) {
-        logger.Info().
-            Str("event_action", "refund_dropped").
-            Str("event_kind", "event").
-            Str("category", "refund").
-            Dict("metadata", zerolog.Dict().
-                Uint64("amount", refundExpiredEvent.Amount).
-                Int64("min_required", bridge.depositFee)).
-            Msg("refund dropped due to amount being less than or equal to deposit fee")
-        
-        err = bridge.subClient.RetrySetRefundTransactionExecutedTx(ctx, refundExpiredEvent.Hash)
-        if err != nil {
-            return err
-        }
-        return nil
-    }	
 
 	signature, sequenceNumber, err := bridge.wallet.CreateRefundAndReturnSignature(ctx, refundExpiredEvent.Target, refundExpiredEvent.Amount, refundExpiredEvent.Hash)
 	if err != nil {

--- a/bridge/tfchain_bridge/pkg/bridge/refund.go
+++ b/bridge/tfchain_bridge/pkg/bridge/refund.go
@@ -14,6 +14,28 @@ import (
 
 // refund handler for stellar
 func (bridge *Bridge) refund(ctx context.Context, destination string, amount int64, tx hProtocol.Transaction) error {
+	if amount <= bridge.depositFee {
+		logger := log.Logger.With().Str("trace_id", tx.ID).Logger()
+
+		logger.Info().
+			Str("event_action", "refund_dropped").
+			Str("event_kind", "event").
+			Str("category", "refund").
+			Dict("metadata", zerolog.Dict().
+				Int64("amount", amount).
+				Int64("min_required", bridge.depositFee)).
+			Msg("refund dropped due to amount being less than or equal to deposit fee")
+
+		// save cursor
+		cursor := tx.PagingToken()
+		err := bridge.blockPersistency.SaveStellarCursor(cursor)
+		if err != nil {
+			return errors.Wrap(err, "an error occurred while saving stellar cursor")
+		}
+
+		return nil
+	}
+
 	err := bridge.handleRefundExpired(ctx, subpkg.RefundTransactionExpiredEvent{
 		Hash:   tx.Hash,
 		Amount: uint64(amount),
@@ -46,6 +68,23 @@ func (bridge *Bridge) handleRefundExpired(ctx context.Context, refundExpiredEven
 			Msg("the transaction has already been refunded")
 		return nil
 	}
+
+    if refundExpiredEvent.Amount <= uint64(bridge.depositFee) {
+        logger.Info().
+            Str("event_action", "refund_dropped").
+            Str("event_kind", "event").
+            Str("category", "refund").
+            Dict("metadata", zerolog.Dict().
+                Uint64("amount", refundExpiredEvent.Amount).
+                Int64("min_required", bridge.depositFee)).
+            Msg("refund dropped due to amount being less than or equal to deposit fee")
+        
+        err = bridge.subClient.RetrySetRefundTransactionExecutedTx(ctx, refundExpiredEvent.Hash)
+        if err != nil {
+            return err
+        }
+        return nil
+    }	
 
 	signature, sequenceNumber, err := bridge.wallet.CreateRefundAndReturnSignature(ctx, refundExpiredEvent.Target, refundExpiredEvent.Amount, refundExpiredEvent.Hash)
 	if err != nil {

--- a/bridge/tfchain_bridge/pkg/bridge/withdraw.go
+++ b/bridge/tfchain_bridge/pkg/bridge/withdraw.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/threefoldtech/tfchain/bridge/tfchain_bridge/pkg"
+	_logger "github.com/threefoldtech/tfchain/bridge/tfchain_bridge/pkg/logger"
 	subpkg "github.com/threefoldtech/tfchain/bridge/tfchain_bridge/pkg/substrate"
 	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
 )
@@ -41,6 +42,7 @@ func (bridge *Bridge) handleWithdrawCreated(ctx context.Context, withdraw subpkg
 
 	// check if it can hold tft : TODO check trust line TFT limit if it can receive the amount
 	if err := bridge.wallet.CheckAccount(withdraw.Target); err != nil {
+		ctx = _logger.WithRefundReason(ctx, err.Error())
 		return bridge.handleBadWithdraw(ctx, withdraw)
 	}
 
@@ -186,14 +188,14 @@ func (bridge *Bridge) handleBadWithdraw(ctx context.Context, withdraw subpkg.Wit
 	logger := log.Logger.With().Str("trace_id", fmt.Sprint(withdraw.ID)).Logger()
 
 	if withdraw.Amount <= uint64(bridge.depositFee) {
-		logger.Info().
-			Str("event_action", "refund_dropped").
-			Str("event_kind", "event").
-			Str("category", "refund").
+		logger.Warn().
+			Str("event_action", "transfer_failed").
+			Str("event_kind", "alert").
+			Str("category", "transfer").
 			Dict("metadata", zerolog.Dict().
-				Uint64("amount", withdraw.Amount).
-				Int64("min_required", bridge.depositFee)).
-			Msg("refund dropped due to amount being less than or equal to deposit fee")
+				Str("reason", _logger.GetRefundReason(ctx))).
+			Str("type", "burn").
+			Msg("a withdraw failed with no remainder to refund (insufficient amount to cover deposit fee)!")
 
 		return bridge.subClient.RetrySetWithdrawExecuted(ctx, withdraw.ID)
 	}

--- a/bridge/tfchain_bridge/pkg/bridge/withdraw.go
+++ b/bridge/tfchain_bridge/pkg/bridge/withdraw.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"strings"
 
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
 	"github.com/rs/zerolog"
@@ -43,13 +42,8 @@ func (bridge *Bridge) handleWithdrawCreated(ctx context.Context, withdraw subpkg
 
 	// check if it can hold tft : TODO check trust line TFT limit if it can receive the amount
 	if err := bridge.wallet.CheckAccount(withdraw.Target); err != nil {
-		if isClientError(err) {
-			ctx = _logger.WithRefundReason(ctx, err.Error())
-			return bridge.handleBadWithdraw(ctx, withdraw)
-		} else {
-			return nil
-		}
-
+		ctx = _logger.WithRefundReason(ctx, err.Error())
+		return bridge.handleBadWithdraw(ctx, withdraw)
 	}
 
 	signature, sequenceNumber, err := bridge.wallet.CreatePaymentAndReturnSignature(ctx, withdraw.Target, withdraw.Amount, withdraw.ID)
@@ -239,25 +233,4 @@ func (bridge *Bridge) handleBadWithdraw(ctx context.Context, withdraw subpkg.Wit
 			Str("to", withdraw.Source.ToHexString())).
 		Msgf("a mint has proposed with the target substrate address of %s", withdraw.Source.ToHexString())
 	return bridge.subClient.RetrySetWithdrawExecuted(ctx, withdraw.ID)
-}
-
-func isClientError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	errMsg := err.Error()
-
-	clientErrors := []string{
-		"address has no trustline",
-		"account not found",
-	}
-
-	for _, clientErr := range clientErrors {
-		if strings.Contains(strings.ToLower(errMsg), strings.ToLower(clientErr)) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/bridge/tfchain_bridge/pkg/bridge/withdraw.go
+++ b/bridge/tfchain_bridge/pkg/bridge/withdraw.go
@@ -184,6 +184,20 @@ func (bridge *Bridge) handleWithdrawReady(ctx context.Context, withdrawReady sub
 
 func (bridge *Bridge) handleBadWithdraw(ctx context.Context, withdraw subpkg.WithdrawCreatedEvent) error {
 	logger := log.Logger.With().Str("trace_id", fmt.Sprint(withdraw.ID)).Logger()
+
+	if withdraw.Amount <= uint64(bridge.depositFee) {
+		logger.Info().
+			Str("event_action", "refund_dropped").
+			Str("event_kind", "event").
+			Str("category", "refund").
+			Dict("metadata", zerolog.Dict().
+				Uint64("amount", withdraw.Amount).
+				Int64("min_required", bridge.depositFee)).
+			Msg("refund dropped due to amount being less than or equal to deposit fee")
+
+		return bridge.subClient.RetrySetWithdrawExecuted(ctx, withdraw.ID)
+	}
+
 	mintID := fmt.Sprintf("refund-%d", withdraw.ID)
 
 	minted, err := bridge.subClient.IsMintedAlready(mintID)

--- a/bridge/tfchain_bridge/pkg/bridge/withdraw.go
+++ b/bridge/tfchain_bridge/pkg/bridge/withdraw.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
 	"github.com/rs/zerolog"
@@ -42,8 +43,13 @@ func (bridge *Bridge) handleWithdrawCreated(ctx context.Context, withdraw subpkg
 
 	// check if it can hold tft : TODO check trust line TFT limit if it can receive the amount
 	if err := bridge.wallet.CheckAccount(withdraw.Target); err != nil {
-		ctx = _logger.WithRefundReason(ctx, err.Error())
-		return bridge.handleBadWithdraw(ctx, withdraw)
+		if isClientError(err) {
+			ctx = _logger.WithRefundReason(ctx, err.Error())
+			return bridge.handleBadWithdraw(ctx, withdraw)
+		} else {
+			return nil
+		}
+
 	}
 
 	signature, sequenceNumber, err := bridge.wallet.CreatePaymentAndReturnSignature(ctx, withdraw.Target, withdraw.Amount, withdraw.ID)
@@ -233,4 +239,25 @@ func (bridge *Bridge) handleBadWithdraw(ctx context.Context, withdraw subpkg.Wit
 			Str("to", withdraw.Source.ToHexString())).
 		Msgf("a mint has proposed with the target substrate address of %s", withdraw.Source.ToHexString())
 	return bridge.subClient.RetrySetWithdrawExecuted(ctx, withdraw.ID)
+}
+
+func isClientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errMsg := err.Error()
+
+	clientErrors := []string{
+		"address has no trustline",
+		"account not found",
+	}
+
+	for _, clientErr := range clientErrors {
+		if strings.Contains(strings.ToLower(errMsg), strings.ToLower(clientErr)) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/bridge/tfchain_bridge/pkg/stellar/stellar.go
+++ b/bridge/tfchain_bridge/pkg/stellar/stellar.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -342,11 +343,43 @@ func (w *StellarWallet) getAccountDetails(address string) (account hProtocol.Acc
 	if err != nil {
 		return hProtocol.Account{}, err
 	}
-	ar := horizonclient.AccountRequest{AccountID: address}
-	account, err = client.AccountDetail(ar)
-	if err != nil {
-		return hProtocol.Account{}, errors.Wrapf(err, "failed to get account details for account: %s", address)
+	
+	retryDelay := 2 * time.Second
+	timeout := 15 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	backOff := backoff.NewExponentialBackOff()
+	backOff.InitialInterval = retryDelay
+	backOff.MaxElapsedTime = timeout
+
+	operation := func() error {
+		ar := horizonclient.AccountRequest{AccountID: address}
+		var opError error
+		account, opError = client.AccountDetail(ar)
+        if opError != nil {
+            log.Debug().
+                Err(opError).
+                Str("stellar_address", address).
+                Msg("failed to get account details, retrying...")
+            return opError
+        }
+        return nil
 	}
+
+	notify := func(err error, d time.Duration) {
+		log.Debug().
+			Err(err).
+			Str("stellar_address", address).
+			Msgf("failed to get account details, retrying in %s", d.String())
+	}
+
+	err = backoff.RetryNotify(operation, backoff.WithContext(backOff,ctx), notify)
+	if err != nil {
+		return hProtocol.Account{}, errors.Wrapf(err, "failed to get account details for account: %s after multiple retries", address)
+	}
+
 	return account, nil
 }
 

--- a/bridge/tfchain_bridge/pkg/stellar/stellar.go
+++ b/bridge/tfchain_bridge/pkg/stellar/stellar.go
@@ -212,7 +212,7 @@ func (w *StellarWallet) CheckAccount(account string) error {
 		}
 	}
 
-	return fmt.Errorf("addess has no trustline")
+	return fmt.Errorf("address has no trustline")
 }
 
 func (w *StellarWallet) generatePaymentOperation(amount uint64, destination string, sequenceNumber int64) (txnbuild.TransactionParams, error) {

--- a/bridge/tfchain_bridge/pkg/stellar/stellar.go
+++ b/bridge/tfchain_bridge/pkg/stellar/stellar.go
@@ -6,11 +6,12 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -343,43 +344,11 @@ func (w *StellarWallet) getAccountDetails(address string) (account hProtocol.Acc
 	if err != nil {
 		return hProtocol.Account{}, err
 	}
-	
-	retryDelay := 2 * time.Second
-	timeout := 15 * time.Second
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	backOff := backoff.NewExponentialBackOff()
-	backOff.InitialInterval = retryDelay
-	backOff.MaxElapsedTime = timeout
-
-	operation := func() error {
-		ar := horizonclient.AccountRequest{AccountID: address}
-		var opError error
-		account, opError = client.AccountDetail(ar)
-        if opError != nil {
-            log.Debug().
-                Err(opError).
-                Str("stellar_address", address).
-                Msg("failed to get account details, retrying...")
-            return opError
-        }
-        return nil
-	}
-
-	notify := func(err error, d time.Duration) {
-		log.Debug().
-			Err(err).
-			Str("stellar_address", address).
-			Msgf("failed to get account details, retrying in %s", d.String())
-	}
-
-	err = backoff.RetryNotify(operation, backoff.WithContext(backOff,ctx), notify)
+	ar := horizonclient.AccountRequest{AccountID: address}
+	account, err = client.AccountDetail(ar)
 	if err != nil {
-		return hProtocol.Account{}, errors.Wrapf(err, "failed to get account details for account: %s after multiple retries", address)
+		return hProtocol.Account{}, errors.Wrapf(err, "failed to get account details for account: %s", address)
 	}
-
 	return account, nil
 }
 
@@ -564,18 +533,46 @@ func (w *StellarWallet) getOperationEffect(txHash string) (ops operations.Operat
 
 // getHorizonClient gets the horizon client based on the wallet's network
 func (w *StellarWallet) getHorizonClient() (*horizonclient.Client, error) {
+	var client *horizonclient.Client
+
 	if w.config.StellarHorizonUrl != "" {
-		return &horizonclient.Client{HorizonURL: w.config.StellarHorizonUrl}, nil
+		client = &horizonclient.Client{HorizonURL: w.config.StellarHorizonUrl}
 	}
 
 	switch w.config.StellarNetwork {
 	case "testnet":
-		return horizonclient.DefaultTestNetClient, nil
+		client = horizonclient.DefaultTestNetClient
 	case "production":
-		return horizonclient.DefaultPublicNetClient, nil
+		client = horizonclient.DefaultPublicNetClient
 	default:
 		return nil, errors.New("network is not supported")
 	}
+
+	// custom HTTP client with retry logic
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = 3
+	retryClient.RetryWaitMin = 2 * time.Second
+	retryClient.RetryWaitMax = 5 * time.Second
+
+	retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+
+		if err != nil {
+			return true, nil
+		}
+
+        if resp.StatusCode == 429 || (resp.StatusCode >= 500 && resp.StatusCode <= 599) {
+            return true, nil
+        }
+
+		return false, nil
+	}
+
+	client.HTTP = retryClient.StandardClient()	
+
+	return client, nil
 }
 
 // getNetworkPassPhrase gets the Stellar network passphrase based on the wallet's network


### PR DESCRIPTION
## Description

- Add retries while getting the Stellar account with a timeout. (used backoff algorithm for better handling)
- In case the refund amount is less than 1 TFT, drop the refund and mark the transaction as executed.
## Related Issues:
-  https://github.com/threefoldtech/tfchain/issues/1039


## Checklist:

Please delete options that are not relevant.

- [ ] My change requires a change to the documentation and I have updated it accordingly
- [ ] My change requires storage migration and I have included and tested it following fork off and try_runtime instructions.
- [ ] I have added tests to cover my changes.
- [ ] I followed the **[Release](https://github.com/threefoldtech/tfchain/blob/development/docs/production/releases.md)** document.
- [ ] My commits follow this [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guide.
