### PR TITLE
Skip transaction if no signatures found

### DIFF
--- a/bridge/docs/observability.md
+++ b/bridge/docs/observability.md
@@ -59,6 +59,7 @@ For example, if a customer is complaining that their deposit never bridged, you 
 - `event_refund_tx_expired_received`: The bridge instance has received TFChain  `RefundTransactionExpired` event.
 - `refund_skipped`: a refund request skipped by the bridge instance as it has already been refunded.
 - `refund_proposed`: a refund has proposed or signed by the bridge instance.
+- `refund_postponed`: a refund has postponed due to a problem in sending this transaction to the stellar network and will be retried later.
 - `refund_completed`: a refund has completed and received on the target stellar account.
 
 ##### Withdraw related 

--- a/bridge/tfchain_bridge/pkg/bridge/refund.go
+++ b/bridge/tfchain_bridge/pkg/bridge/refund.go
@@ -91,10 +91,10 @@ func (bridge *Bridge) handleRefundReady(ctx context.Context, refundReadyEvent su
 
 	if len(refund.Signatures) == 0 {
 		logger.Info().
-			Str("event_action", "refund_skipped").
+			Str("event_action", "refund_postponed").
 			Str("event_kind", "event").
 			Str("category", "refund").
-			Msg("the refund has been skipped because it has no signatures")
+			Msg("the refund has been postponed due to a problem in sending this transaction to the stellar network. error was no signatures")
 		return nil
 	}
 

--- a/bridge/tfchain_bridge/pkg/bridge/refund.go
+++ b/bridge/tfchain_bridge/pkg/bridge/refund.go
@@ -94,7 +94,7 @@ func (bridge *Bridge) handleRefundReady(ctx context.Context, refundReadyEvent su
 			Str("event_action", "refund_postponed").
 			Str("event_kind", "event").
 			Str("category", "refund").
-			Msg("the refund has been postponed due to a problem in sending this transaction to the stellar network. error was no signatures")
+			Msg("the refund has been postponed due to the transaction signatures being removed on the TFChain side while the bridge was processing the transaction")
 		return nil
 	}
 

--- a/bridge/tfchain_bridge/pkg/bridge/refund.go
+++ b/bridge/tfchain_bridge/pkg/bridge/refund.go
@@ -89,6 +89,15 @@ func (bridge *Bridge) handleRefundReady(ctx context.Context, refundReadyEvent su
 		return err
 	}
 
+	if len(refund.Signatures) == 0 {
+		logger.Info().
+			Str("event_action", "refund_skipped").
+			Str("event_kind", "event").
+			Str("category", "refund").
+			Msg("the refund has been skipped because it has no signatures")
+		return nil
+	}
+
 	// Todo, retry here?
 	if err = bridge.wallet.CreateRefundPaymentWithSignaturesAndSubmit(ctx, refund.Target, uint64(refund.Amount), refund.TxHash, refund.Signatures, int64(refund.SequenceNumber)); err != nil {
 		return err

--- a/bridge/tfchain_bridge/pkg/bridge/withdraw.go
+++ b/bridge/tfchain_bridge/pkg/bridge/withdraw.go
@@ -153,7 +153,7 @@ func (bridge *Bridge) handleWithdrawReady(ctx context.Context, withdrawReady sub
 			Str("event_action", "withdraw_postponed").
 			Str("event_kind", "event").
 			Str("category", "withdraw").
-			Msg("the withdraw has been postponed due to a problem in sending this transaction to the stellar network. error was no signatures")
+			Msg("the withdraw has been postponed due to the transaction signatures being removed on the TFChain side while the bridge was processing the transaction")
 		return nil
 	}
 

--- a/bridge/tfchain_bridge/pkg/bridge/withdraw.go
+++ b/bridge/tfchain_bridge/pkg/bridge/withdraw.go
@@ -150,10 +150,10 @@ func (bridge *Bridge) handleWithdrawReady(ctx context.Context, withdrawReady sub
 
 	if len(burnTx.Signatures) == 0 {
 		logger.Info().
-			Str("event_action", "withdraw_skipped").
+			Str("event_action", "withdraw_postponed").
 			Str("event_kind", "event").
 			Str("category", "withdraw").
-			Msg("the withdraw has been skipped because it has no signatures")
+			Msg("the withdraw has been postponed due to a problem in sending this transaction to the stellar network. error was no signatures")
 		return nil
 	}
 

--- a/bridge/tfchain_bridge/pkg/bridge/withdraw.go
+++ b/bridge/tfchain_bridge/pkg/bridge/withdraw.go
@@ -149,7 +149,12 @@ func (bridge *Bridge) handleWithdrawReady(ctx context.Context, withdrawReady sub
 	}
 
 	if len(burnTx.Signatures) == 0 {
-		return pkg.ErrNoSignatures
+		logger.Info().
+			Str("event_action", "withdraw_skipped").
+			Str("event_kind", "event").
+			Str("category", "withdraw").
+			Msg("the withdraw has been skipped because it has no signatures")
+		return nil
 	}
 
 	// todo add memo hash


### PR DESCRIPTION
## Description

- In case the signatures are gone from the transaction while handling the ready events, we should just ignore the transactions.
## Related Issues:

- https://github.com/threefoldtech/tfchain/issues/1038

## Checklist:

Please delete options that are not relevant.

- [ ] My change requires a change to the documentation and I have updated it accordingly
- [ ] My change requires storage migration and I have included and tested it following fork off and try_runtime instructions.
- [ ] I have added tests to cover my changes.
- [ ] I followed the **[Release](https://github.com/threefoldtech/tfchain/blob/development/docs/production/releases.md)** document.
- [ ] My commits follow this [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guide.
