### PR TITLE
Should not allow minting if the sender account is the bridge account 

### DIFF
--- a/bridge/tfchain_bridge/main.go
+++ b/bridge/tfchain_bridge/main.go
@@ -29,6 +29,37 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "sets debug level log output")
 
 	flag.Parse()
+	if flag.NArg() > 0 {
+		log.Fatal().
+			Strs("unexpected_args", flag.Args()).
+			Str("event_action", "bridge_init_aborted").
+			Str("event_kind", "error").
+			Str("category", "configuration").
+			Msg("unexpected positional arguments provided, did you forget a flag?")
+	}
+
+	missingParams := []string{}
+	if bridgeCfg.TfchainURL == "" {
+		missingParams = append(missingParams, "tfchainurl")
+	}
+	if bridgeCfg.TfchainSeed == "" {
+		missingParams = append(missingParams, "tfchainseed")
+	}
+	if bridgeCfg.StellarBridgeAccount == "" {
+		missingParams = append(missingParams, "bridgewallet")
+	}
+	if bridgeCfg.StellarSeed == "" {
+		missingParams = append(missingParams, "secret")
+	}
+
+	if len(missingParams) > 0 {
+		log.Fatal().
+			Strs("missing_parameters", missingParams).
+			Str("event_action", "bridge_init_aborted").
+			Str("event_kind", "error").
+			Str("category", "configuration").
+			Msg("required parameters are missing")
+	}
 
 	logger.InitLogger(debug)
 

--- a/bridge/tfchain_bridge/pkg/bridge/mint.go
+++ b/bridge/tfchain_bridge/pkg/bridge/mint.go
@@ -19,6 +19,23 @@ import (
 func (bridge *Bridge) mint(ctx context.Context, senders map[string]*big.Int, tx hProtocol.Transaction) error {
 	logger := log.Logger.With().Str("trace_id", tx.ID).Logger()
 
+	filteredSenders := make(map[string]*big.Int)
+	for sender := range senders {
+		if sender == bridge.wallet.GetKeypair().Address() {
+			logger.Info().
+				Str("event_action", "mint_rejected").
+				Str("event_kind", "event").
+				Str("category", "mint").
+				Dict("metadata", zerolog.Dict().
+					Str("reason", "sender is bridge account").
+					Str("sender", sender)).
+				Msg("rejecting mint from bridge account to prevent circular transactions")
+		} else {
+			filteredSenders[sender] = senders[sender]
+		}
+	}
+
+	senders = filteredSenders
 	minted, err := bridge.subClient.IsMintedAlready(tx.Hash)
 	if err != nil {
 		if !errors.Is(err, substrate.ErrMintTransactionNotFound) {

--- a/bridge/tfchain_bridge/pkg/bridge/mint.go
+++ b/bridge/tfchain_bridge/pkg/bridge/mint.go
@@ -19,23 +19,20 @@ import (
 func (bridge *Bridge) mint(ctx context.Context, senders map[string]*big.Int, tx hProtocol.Transaction) error {
 	logger := log.Logger.With().Str("trace_id", tx.ID).Logger()
 
-	filteredSenders := make(map[string]*big.Int)
-	for sender := range senders {
-		if sender == bridge.wallet.GetKeypair().Address() {
-			logger.Info().
-				Str("event_action", "mint_rejected").
-				Str("event_kind", "event").
-				Str("category", "mint").
-				Dict("metadata", zerolog.Dict().
-					Str("reason", "sender is bridge account").
-					Str("sender", sender)).
-				Msg("rejecting mint from bridge account to prevent circular transactions")
-		} else {
-			filteredSenders[sender] = senders[sender]
-		}
+	bridgeAddress := bridge.wallet.GetKeypair().Address()
+	if _, isBridgeSender := senders[bridgeAddress]; isBridgeSender {
+		logger.Info().
+			Str("event_action", "mint_rejected").
+			Str("event_kind", "event").
+			Str("category", "mint").
+			Dict("metadata", zerolog.Dict().
+				Str("reason", "sender is bridge account").
+				Str("sender", bridgeAddress)).
+			Msg("rejecting mint from bridge account to prevent circular transactions")
+
+		delete(senders, bridgeAddress)
 	}
 
-	senders = filteredSenders
 	minted, err := bridge.subClient.IsMintedAlready(tx.Hash)
 	if err != nil {
 		if !errors.Is(err, substrate.ErrMintTransactionNotFound) {

--- a/bridge/tfchain_bridge/pkg/bridge/mint.go
+++ b/bridge/tfchain_bridge/pkg/bridge/mint.go
@@ -19,20 +19,6 @@ import (
 func (bridge *Bridge) mint(ctx context.Context, senders map[string]*big.Int, tx hProtocol.Transaction) error {
 	logger := log.Logger.With().Str("trace_id", tx.ID).Logger()
 
-	bridgeAddress := bridge.wallet.GetKeypair().Address()
-	if _, isBridgeSender := senders[bridgeAddress]; isBridgeSender {
-		logger.Info().
-			Str("event_action", "mint_rejected").
-			Str("event_kind", "event").
-			Str("category", "mint").
-			Dict("metadata", zerolog.Dict().
-				Str("reason", "sender is bridge account").
-				Str("sender", bridgeAddress)).
-			Msg("rejecting mint from bridge account to prevent circular transactions")
-
-		delete(senders, bridgeAddress)
-	}
-
 	minted, err := bridge.subClient.IsMintedAlready(tx.Hash)
 	if err != nil {
 		if !errors.Is(err, substrate.ErrMintTransactionNotFound) {

--- a/bridge/tfchain_bridge/pkg/stellar/stellar.go
+++ b/bridge/tfchain_bridge/pkg/stellar/stellar.go
@@ -456,7 +456,7 @@ func (w *StellarWallet) processTransaction(tx hProtocol.Transaction) ([]MintEven
 			}
 
 			PaymentOperation := op.(operations.Payment)
-			if PaymentOperation.To != w.config.StellarBridgeAccount {
+			if PaymentOperation.To != w.config.StellarBridgeAccount || PaymentOperation.From == w.config.StellarBridgeAccount{
 				continue
 			}
 


### PR DESCRIPTION
## Description

- Should not allow minting if the sender account is the bridge account.
- Fixed cmd issue, check on unexpected positional arguments and missing parameters.
## Related Issues:

- #1041 
- #1044

## Checklist:

Please delete options that are not relevant.

- [ ] My change requires a change to the documentation and I have updated it accordingly
- [ ] My change requires storage migration and I have included and tested it following fork off and try_runtime instructions.
- [ ] I have added tests to cover my changes.
- [ ] I followed the **[Release](https://github.com/threefoldtech/tfchain/blob/development/docs/production/releases.md)** document.
- [ ] My commits follow this [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guide.
