### PR TITLE
Bump artifact actions version to v4

### DIFF
--- a/.github/workflows/010_build_and_test.yaml
+++ b/.github/workflows/010_build_and_test.yaml
@@ -54,7 +54,7 @@ jobs:
           cd substrate-node/tests
           robot -d _output_tests/ .
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: integration test output

--- a/.github/workflows/030_create_release.yaml
+++ b/.github/workflows/030_create_release.yaml
@@ -37,13 +37,13 @@ jobs:
           echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
 
       - name: Upload tfchain srtool json
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tfchain-srtool-digest-json
           path: tfchain-srtool-digest.json
 
       - name: Upload runtime
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tfchain-runtime
           path: substrate-node/${{ steps.srtool_build.outputs.wasm_compressed }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Download artifacts
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tfchain-runtime
           path: tfchain-runtime


### PR DESCRIPTION
## Description

Bump artifact actions version to v4
Since the artifact name is unique per workflow run, upgrading won't cause issues with v4's immutability

Context: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md


## Related Issues:

- https://github.com/threefoldtech/tfchain/issues/1052

## Checklist:

- [X] My commits follow this [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guide.
