### PR TITLE
Development fix runtime benchmarks

### DIFF
--- a/.github/workflows/070_lint_and_test_go_bridge.yaml
+++ b/.github/workflows/070_lint_and_test_go_bridge.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: staticcheck
         uses: dominikh/staticcheck-action@v1.3.0
         with:
-          version: "2022.1.3"
+          version: "latest"
           working-directory: bridge/tfchain_bridge
         env:
           GO111MODULE: on

--- a/clients/tfchain-client-go/node.go
+++ b/clients/tfchain-client-go/node.go
@@ -857,28 +857,48 @@ func (s *Substrate) GetAllowedTwinAdmins() ([]AccountID, error) {
 }
 
 // IsNodeOptedOutOfV3Billing returns true if the node has opted out of v3 billing.
+// Deprecated: use GetNodeV3BillingOptOutTimestamp to also retrieve the opt-out time.
 func (s *Substrate) IsNodeOptedOutOfV3Billing(nodeID uint32) (bool, error) {
-	cl, meta, err := s.GetClient()
+	ts, err := s.GetNodeV3BillingOptOutTimestamp(nodeID)
 	if err != nil {
 		return false, err
+	}
+	return ts != nil, nil
+}
+
+// GetNodeV3BillingOptOutTimestamp returns the Unix timestamp (seconds) at which the node
+// opted out of v3 billing, or nil if the node has not opted out.
+func (s *Substrate) GetNodeV3BillingOptOutTimestamp(nodeID uint32) (*uint64, error) {
+	cl, meta, err := s.GetClient()
+	if err != nil {
+		return nil, err
 	}
 
 	bytes, err := Encode(nodeID)
 	if err != nil {
-		return false, errors.Wrap(err, "substrate: encoding error building query arguments")
+		return nil, errors.Wrap(err, "substrate: encoding error building query arguments")
 	}
 
 	key, err := types.CreateStorageKey(meta, "TfgridModule", "NodeV3BillingOptOut", bytes)
 	if err != nil {
-		return false, errors.Wrap(err, "failed to create substrate query key")
+		return nil, errors.Wrap(err, "failed to create substrate query key")
 	}
 
 	raw, err := cl.RPC.State.GetStorageRawLatest(key)
 	if err != nil {
-		return false, errors.Wrap(err, "failed to lookup node v3 billing opt-out")
+		return nil, errors.Wrap(err, "failed to lookup node v3 billing opt-out")
 	}
 
-	return len(*raw) > 0, nil
+	if len(*raw) == 0 {
+		return nil, nil
+	}
+
+	var ts uint64
+	if err := Decode(*raw, &ts); err != nil {
+		return nil, errors.Wrap(err, "failed to decode node v3 billing opt-out timestamp")
+	}
+
+	return &ts, nil
 }
 
 // SetNodeCertificate sets the node certificate type

--- a/clients/tfchain-client-go/node.go
+++ b/clients/tfchain-client-go/node.go
@@ -826,48 +826,6 @@ func (s *Substrate) OptOutOfV3Billing(identity Identity, nodeID uint32) (hash ty
 	return callResponse.Hash, nil
 }
 
-// AddTwinAdmin adds an account to the list of twin admins allowed to deploy on opted-out nodes.
-// Requires council (restricted) origin.
-func (s *Substrate) AddTwinAdmin(identity Identity, account AccountID) (hash types.Hash, err error) {
-	cl, meta, err := s.GetClient()
-	if err != nil {
-		return hash, err
-	}
-
-	c, err := types.NewCall(meta, "TfgridModule.add_twin_admin", account)
-	if err != nil {
-		return hash, errors.Wrap(err, "failed to create call")
-	}
-
-	callResponse, err := s.Call(cl, meta, identity, c)
-	if err != nil {
-		return hash, errors.Wrap(err, "failed to add twin admin")
-	}
-
-	return callResponse.Hash, nil
-}
-
-// RemoveTwinAdmin removes an account from the list of twin admins allowed to deploy on opted-out nodes.
-// Requires council (restricted) origin.
-func (s *Substrate) RemoveTwinAdmin(identity Identity, account AccountID) (hash types.Hash, err error) {
-	cl, meta, err := s.GetClient()
-	if err != nil {
-		return hash, err
-	}
-
-	c, err := types.NewCall(meta, "TfgridModule.remove_twin_admin", account)
-	if err != nil {
-		return hash, errors.Wrap(err, "failed to create call")
-	}
-
-	callResponse, err := s.Call(cl, meta, identity, c)
-	if err != nil {
-		return hash, errors.Wrap(err, "failed to remove twin admin")
-	}
-
-	return callResponse.Hash, nil
-}
-
 // GetAllowedTwinAdmins returns the list of accounts allowed to deploy on opted-out nodes.
 // Returns an empty slice if no admins have been configured.
 func (s *Substrate) GetAllowedTwinAdmins() ([]AccountID, error) {

--- a/clients/tfchain-client-go/node_test.go
+++ b/clients/tfchain-client-go/node_test.go
@@ -89,32 +89,6 @@ func TestOptOutOfV3Billing(t *testing.T) {
 	require.True(t, optedOut)
 }
 
-func TestGetAllowedTwinAdmins(t *testing.T) {
-	cl := startLocalConnection(t)
-	defer cl.Close()
-
-	rootIdentity, err := NewIdentityFromSr25519Phrase(AliceMnemonics)
-	require.NoError(t, err)
-
-	bobAccount, err := FromAddress(BobAddress)
-	require.NoError(t, err)
-
-	// Ensure Bob is in the list
-	_, err = cl.AddTwinAdmin(rootIdentity, bobAccount)
-	require.NoError(t, err)
-	admins, err := cl.GetAllowedTwinAdmins()
-	require.NoError(t, err)
-	require.Contains(t, admins, bobAccount)
-
-	// Clean up
-	_, err = cl.RemoveTwinAdmin(rootIdentity, bobAccount)
-	require.NoError(t, err)
-
-	admins, err = cl.GetAllowedTwinAdmins()
-	require.NoError(t, err)
-	require.NotContains(t, admins, bobAccount)
-}
-
 func TestUptimeReport(t *testing.T) {
 	cl := startLocalConnection(t)
 	defer cl.Close()

--- a/clients/tfchain-client-js/lib/client.js
+++ b/clients/tfchain-client-js/lib/client.js
@@ -19,7 +19,7 @@ const {
 const {
   createNode, updateNode, getNode,
   getNodeIDByPubkey, deleteNode, listNodes,
-  optOutOfV3Billing, getAllowedTwinAdmins, isNodeOptedOutOfV3Billing
+  optOutOfV3Billing, getAllowedTwinAdmins, isNodeOptedOutOfV3Billing, getNodeV3BillingOptOutTimestamp
 } = require('./node')
 const { signEntityTwinID, signEntityCreation } = require('./sign')
 const { getBalance, transfer } = require('./balance')
@@ -220,6 +220,10 @@ class Client {
 
   async isNodeOptedOutOfV3Billing(nodeID) {
     return isNodeOptedOutOfV3Billing(this, nodeID)
+  }
+
+  async getNodeV3BillingOptOutTimestamp(nodeID) {
+    return getNodeV3BillingOptOutTimestamp(this, nodeID)
   }
 
   async setNodePower (nodeId, power, callback) {

--- a/clients/tfchain-client-js/lib/client.js
+++ b/clients/tfchain-client-js/lib/client.js
@@ -18,7 +18,8 @@ const {
 } = require('./farms')
 const {
   createNode, updateNode, getNode,
-  getNodeIDByPubkey, deleteNode, listNodes
+  getNodeIDByPubkey, deleteNode, listNodes,
+  optOutOfV3Billing, getAllowedTwinAdmins, isNodeOptedOutOfV3Billing
 } = require('./node')
 const { signEntityTwinID, signEntityCreation } = require('./sign')
 const { getBalance, transfer } = require('./balance')
@@ -207,6 +208,18 @@ class Client {
 
   async deleteNode(id, callback) {
     return deleteNode(this, id, callback)
+  }
+
+  async optOutOfV3Billing(nodeID, callback) {
+    return optOutOfV3Billing(this, nodeID, callback)
+  }
+
+  async getAllowedTwinAdmins() {
+    return getAllowedTwinAdmins(this)
+  }
+
+  async isNodeOptedOutOfV3Billing(nodeID) {
+    return isNodeOptedOutOfV3Billing(this, nodeID)
   }
 
   async setNodePower (nodeId, power, callback) {

--- a/clients/tfchain-client-js/lib/node.js
+++ b/clients/tfchain-client-js/lib/node.js
@@ -134,22 +134,6 @@ async function optOutOfV3Billing (self, nodeID, callback) {
     .signAndSend(self.key, { nonce }, callback)
 }
 
-// addTwinAdmin adds an account to the list of twin admins (council origin)
-async function addTwinAdmin (self, account, callback) {
-  const nonce = await self.api.rpc.system.accountNextIndex(self.address)
-  return self.api.tx.tfgridModule
-    .addTwinAdmin(account)
-    .signAndSend(self.key, { nonce }, callback)
-}
-
-// removeTwinAdmin removes an account from the list of twin admins (council origin)
-async function removeTwinAdmin (self, account, callback) {
-  const nonce = await self.api.rpc.system.accountNextIndex(self.address)
-  return self.api.tx.tfgridModule
-    .removeTwinAdmin(account)
-    .signAndSend(self.key, { nonce }, callback)
-}
-
 // getAllowedTwinAdmins returns the list of accounts allowed to deploy on opted-out nodes
 async function getAllowedTwinAdmins (self) {
   const result = await self.api.query.tfgridModule.allowedTwinAdmins()
@@ -177,8 +161,6 @@ module.exports = {
   deleteNode,
   listNodes,
   optOutOfV3Billing,
-  addTwinAdmin,
-  removeTwinAdmin,
   getAllowedTwinAdmins,
   isNodeOptedOutOfV3Billing
 }

--- a/clients/tfchain-client-js/lib/node.js
+++ b/clients/tfchain-client-js/lib/node.js
@@ -140,10 +140,18 @@ async function getAllowedTwinAdmins (self) {
   return result.toJSON() || []
 }
 
-// isNodeOptedOutOfV3Billing returns true if the node has opted out of v3 billing
+// isNodeOptedOutOfV3Billing returns true if the node has opted out of v3 billing.
+// Deprecated: use getNodeV3BillingOptOutTimestamp to also retrieve the opt-out time.
 async function isNodeOptedOutOfV3Billing (self, nodeID) {
+  return (await getNodeV3BillingOptOutTimestamp(self, nodeID)) !== null
+}
+
+// getNodeV3BillingOptOutTimestamp returns the Unix timestamp (seconds) at which the node
+// opted out of v3 billing, or null if the node has not opted out.
+async function getNodeV3BillingOptOutTimestamp (self, nodeID) {
   const result = await self.api.query.tfgridModule.nodeV3BillingOptOut(nodeID)
-  return !result.isNone
+  if (result.isNone) return null
+  return result.unwrap().toNumber()
 }
 
 async function validateNode (self, farmID) {
@@ -162,5 +170,6 @@ module.exports = {
   listNodes,
   optOutOfV3Billing,
   getAllowedTwinAdmins,
-  isNodeOptedOutOfV3Billing
+  isNodeOptedOutOfV3Billing,
+  getNodeV3BillingOptOutTimestamp
 }

--- a/substrate-node/pallets/pallet-dao/src/mock.rs
+++ b/substrate-node/pallets/pallet-dao/src/mock.rs
@@ -145,6 +145,7 @@ parameter_types! {
     pub const MaxInterfaceIpsLength: u32 = 5;
     pub const MaxInterfacesLength: u32 = 10;
     pub const MaxFarmPublicIps: u32 = 512;
+    pub const MaxTwinAdmins: u32 = 10;
     pub const TimestampHintDrift: u64 = 60;
 }
 
@@ -172,6 +173,7 @@ impl pallet_tfgrid::Config for TestRuntime {
     type FarmName = TestFarmName;
     type MaxFarmNameLength = MaxFarmNameLength;
     type MaxFarmPublicIps = MaxFarmPublicIps;
+    type MaxTwinAdmins = MaxTwinAdmins;
     type MaxInterfacesLength = MaxInterfacesLength;
     type InterfaceName = TestInterfaceName;
     type InterfaceMac = TestInterfaceMac;


### PR DESCRIPTION
## Description

This fix an error surfaced when compile dao pallet with --features runtime-benchmarks flag 

The benchmark test suite macro (impl_benchmark_test_suite!) pulls in the mock runtime to run benchmark logic as unit tests, so the mock needs to satisfy the full Config trait including MaxTwinAdmins. Without that feature flag, the mock compiles fine because benchmarking code is gated behind `#[cfg(feature = "runtime-benchmarks")]`.

- Production: unaffected — runtime was already correct
- Normal cargo test: unaffected — dao mock compiled fine without the benchmark feature
- `--features runtime-benchmarks`: now fixed

PR include also:
- A minor ci fix
- The removal of admin calls from the clients since these require council flow (atm clients not include support for collective pallet, but can be added later).


## Related Issues

- fixes https://github.com/threefoldtech/tfchain/issues/1071
- fixes https://github.com/threefoldtech/tfchain/issues/1072
- fixes https://github.com/threefoldtech/tfchain/issues/1073