### PR TITLE
fix(ci): update bridge lint workflow for Go 1.21

### DIFF
--- a/.github/workflows/070_lint_and_test_go_bridge.yaml
+++ b/.github/workflows/070_lint_and_test_go_bridge.yaml
@@ -11,7 +11,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    steps:    
+    steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -23,27 +23,29 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.21"
           cache: false
-          # cache-dependency-path: bridge/tfchain_bridge/go.sum
         id: go
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout 3m --verbose
           working-directory: bridge/tfchain_bridge
 
       - name: staticcheck
-        uses: dominikh/staticcheck-action@v1.3.0
+        uses: dominikh/staticcheck-action@v1
         with:
           version: "latest"
           working-directory: bridge/tfchain_bridge
-        env:
-          GO111MODULE: on
 
       - name: gofmt
-        uses: Jerome1337/gofmt-action@v1.0.5
-        with:
-          gofmt-path: './bridge/tfchain_bridge'
-          gofmt-flags: "-l -d"
+        run: |
+          cd bridge/tfchain_bridge
+          UNFORMATTED=$(gofmt -l .)
+          if [ -n "$UNFORMATTED" ]; then
+            echo "Files not formatted:"
+            echo "$UNFORMATTED"
+            gofmt -d .
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

The bridge lint workflow (`070_lint_and_test_go_bridge.yaml`) fails because:
- `staticcheck-action@v1.3.0` bundles `setup-go-faster` which tries to install Go 1.19
- `go.mod` requires Go 1.21 — the old tooling can't handle it

## Changes

- **Go version**: 1.20 → 1.21 (match `go.mod`)
- **golangci-lint-action**: v3.7.0 → v6 (Go 1.21+ support)
- **staticcheck-action**: v1.3.0 → v1 (uses `setup-go` internally, no more bundled Go 1.19)
- **gofmt**: replaced `Jerome1337/gofmt-action@v1.0.5` (unmaintained, last updated 2020) with inline `gofmt -l` check