### PR TITLE
fix(ci): correct git safe.directory path in benchmark weights workflow

### DIFF
--- a/.github/workflows/060_generate_benchmark_weights.yml
+++ b/.github/workflows/060_generate_benchmark_weights.yml
@@ -69,7 +69,7 @@ jobs:
           
       - name: Git config
         run: |
-          git config --global --add safe.directory /__w/tfchain/tfchain
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git status
 
       - name: Commit & Push changes


### PR DESCRIPTION
## Problem

The `Generate benchmark weights` workflow fails at the **Git config** step:

```
fatal: detected dubious ownership in repository at '/__w/ledger_chain/ledger_chain'
Error: Process completed with exit code 128.
```

After the repository rename (`tfchain` → `ledger_chain`), the runner checks the repo out at `/__w/ledger_chain/ledger_chain`, but `060_generate_benchmark_weights.yml` hardcoded the `safe.directory` exception to the old path `/__w/tfchain/tfchain`. The exception no longer matches the actual checkout path, so git refuses to operate on the repo.

The benchmark step that runs *before* this (`./target/production/tfchain benchmark ...`) succeeds, so the binary name is unaffected — this `safe.directory` line is the only break.

## Fix

Use `$GITHUB_WORKSPACE` (set by the runner to the real checkout path regardless of repo name) instead of the hardcoded path:

```diff
-          git config --global --add safe.directory /__w/tfchain/tfchain
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
```

Rename-proof; no other workflow hardcodes the old path (grep-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)