### PR TITLE
fix(pallet-tft-bridge): reject creating an already-executed refund

### DIFF
--- a/substrate-node/pallets/pallet-tft-bridge/src/tests.rs
+++ b/substrate-node/pallets/pallet-tft-bridge/src/tests.rs
@@ -610,6 +610,52 @@ fn refund_signature_after_expiry_resets_block_and_survives() {
     });
 }
 
+#[test]
+fn creating_refund_for_already_executed_transaction_fails() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(TFTBridgeModule::add_bridge_validator(
+            RawOrigin::Root.into(),
+            alice()
+        ));
+
+        let tx_hash = b"some_tx".to_vec();
+
+        // Create the refund and add a signature. With a single validator this
+        // immediately reaches the signature threshold.
+        assert_ok!(TFTBridgeModule::create_refund_transaction_or_add_sig(
+            RuntimeOrigin::signed(alice()),
+            tx_hash.clone(),
+            b"some_target".to_vec(),
+            2,
+            b"some_signature".to_vec(),
+            b"some_pub_key".to_vec(),
+            0,
+        ));
+
+        // Mark it executed: moves it from RefundTransactions to
+        // ExecutedRefundTransactions.
+        assert_ok!(TFTBridgeModule::set_refund_transaction_executed(
+            RuntimeOrigin::signed(alice()),
+            tx_hash.clone(),
+        ));
+
+        // Re-creating the same refund must be rejected, not silently recreated
+        // (which would re-arm the on_finalize retry/crash loop).
+        assert_noop!(
+            TFTBridgeModule::create_refund_transaction_or_add_sig(
+                RuntimeOrigin::signed(alice()),
+                tx_hash.clone(),
+                b"some_target".to_vec(),
+                2,
+                b"some_signature".to_vec(),
+                b"some_pub_key".to_vec(),
+                0,
+            ),
+            Error::<TestRuntime>::RefundTransactionAlreadyExecuted
+        );
+    });
+}
+
 fn prepare_validators() {
     TFTBridgeModule::add_bridge_validator(RawOrigin::Root.into(), alice()).unwrap();
     TFTBridgeModule::add_bridge_validator(RawOrigin::Root.into(), bob()).unwrap();

--- a/substrate-node/pallets/pallet-tft-bridge/src/tft_bridge.rs
+++ b/substrate-node/pallets/pallet-tft-bridge/src/tft_bridge.rs
@@ -120,6 +120,15 @@ impl<T: Config> Pallet<T> {
     ) -> DispatchResultWithPostInfo {
         Self::check_if_validator_exists(validator.clone())?;
 
+        // check if it already has been executed in the past, mirroring the mint
+        // and burn paths. Without this guard a refund that was already executed
+        // (e.g. quarantined by the bridge) would be silently recreated, re-arming
+        // the on_finalize retry loop.
+        ensure!(
+            !ExecutedRefundTransactions::<T>::contains_key(tx_hash.clone()),
+            Error::<T>::RefundTransactionAlreadyExecuted
+        );
+
         // make sure we don't duplicate the transaction
         // ensure!(!MintTransactions::<T>::contains_key(tx_id.clone()), Error::<T>::MintTransactionExists);
         if RefundTransactions::<T>::contains_key(tx_hash.clone()) {


### PR DESCRIPTION
## Problem

`create_stellar_refund_transaction_or_add_sig` only checked whether the refund existed in `RefundTransactions`, not whether it had already been executed. A refund that was already executed — e.g. quarantined by the bridge after a permanently undeliverable Stellar submission (see #1089 / companion bridge PR) — could be silently recreated, re-arming the `on_finalize` retry loop.

This is also a consistency gap: the mint and burn paths already guard against re-creating an executed transaction; the refund path was the lone exception.

- `propose_or_vote_stellar_mint_transaction` → checks `ExecutedMintTransactions`
- `propose_stellar_burn_transaction_or_add_sig` → checks `ExecutedBurnTransactions`
- `create_stellar_refund_transaction_or_add_sig` → **checked neither** (only `RefundTransactions::contains_key`)

## Fix

Add an `ExecutedRefundTransactions` guard, returning `RefundTransactionAlreadyExecuted`, mirroring the mint/burn checks.

The bridge already recovers from this error gracefully: `RetryCreateRefundTransactionOrAddSig` re-checks `IsRefundedAlready` after a failed create and exits cleanly, so no bridge change is required.

## Scope notes

- **No `spec_version` bump.** Per `docs/production/releases.md`, version/spec bumps are a release-time step (`make version-bump`). This PR is a runtime logic change and **requires a runtime upgrade** at release.
- No storage migration: the guard reads an existing storage map; no layout change.
- No new events/extrinsics; `transaction_version` unchanged.

## Tests

TDD: added `creating_refund_for_already_executed_transaction_fails` (watched it fail — re-creation returned `Ok` instead of the error — then added the guard). Full pallet suite: 19 passed.

Refs #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)