### PR TITLE
fix(bridge): correct Stellar deposit asset validation

### DIFF
--- a/bridge/tfchain_bridge/pkg/stellar/stellar.go
+++ b/bridge/tfchain_bridge/pkg/stellar/stellar.go
@@ -512,7 +512,11 @@ func (w *StellarWallet) processTransaction(tx hProtocol.Transaction) ([]MintEven
 		}
 
 		creditedEffect := effect.(horizoneffects.AccountCredited)
-		if creditedEffect.Code != asset[0] && creditedEffect.Issuer != asset[1] {
+		// Skip the effect unless BOTH the asset code and issuer match the
+		// bridge's TFT asset. Using && here meant a credit was only skipped
+		// when both differed, so a credit with the right code but a wrong
+		// issuer (or vice-versa) slipped through and could be minted.
+		if creditedEffect.Code != asset[0] || creditedEffect.Issuer != asset[1] {
 			continue
 		}
 
@@ -523,12 +527,34 @@ func (w *StellarWallet) processTransaction(tx hProtocol.Transaction) ([]MintEven
 
 		senders := make(map[string]*big.Int)
 		for _, op := range ops.Embedded.Records {
+			// Skip non-payment operations individually. Previously this
+			// returned from the whole function on the first non-payment op,
+			// silently dropping any legitimate payment ops in the same
+			// transaction (lost deposits / missing mints).
 			if op.GetType() != "payment" {
-				return nil, nil
+				continue
 			}
 
 			PaymentOperation := op.(operations.Payment)
 			if PaymentOperation.To != w.config.StellarBridgeAccount || PaymentOperation.From == w.config.StellarBridgeAccount {
+				continue
+			}
+
+			// Validate the payment asset at the operation level too. The
+			// account_credited effect check above gates entry into this loop,
+			// but the per-payment amount must itself be TFT — otherwise a
+			// non-TFT payment to the bridge in the same transaction would be
+			// summed and minted as TFT.
+			if PaymentOperation.Code != asset[0] || PaymentOperation.Issuer != asset[1] {
+				logger.Warn().
+					Str("event_action", "non_tft_payment_rejected").
+					Str("event_kind", "alert").
+					Str("from", PaymentOperation.From).
+					Str("asset_code", PaymentOperation.Code).
+					Str("asset_issuer", PaymentOperation.Issuer).
+					Str("amount", PaymentOperation.Amount).
+					Str("tx_hash", PaymentOperation.TransactionHash).
+					Msg("non-TFT payment to bridge detected — skipping")
 				continue
 			}
 
@@ -677,7 +703,10 @@ func (w *StellarWallet) StatBridgeAccount() (string, error) {
 	asset := w.getAssetCodeAndIssuer()
 
 	for _, balance := range acc.Balances {
-		if balance.Code == asset[0] || balance.Issuer == asset[1] {
+		// Match the TFT balance on BOTH code and issuer. Using || could
+		// return an unrelated asset's balance that happened to share either
+		// the code or the issuer.
+		if balance.Code == asset[0] && balance.Issuer == asset[1] {
 			return balance.Balance, nil
 		}
 	}


### PR DESCRIPTION
## Summary

Four correctness fixes to the Stellar→TFChain **deposit/mint** path (`pkg/stellar/stellar.go`). These were identified while decomposing the larger batching/idempotency work (#1079) into independently-shippable pieces. They are **bridge-only, no runtime upgrade**, and independent of the idempotency/batching changes.

Two of the four are **fund-safety** issues that exist on `development` today.

## Changes

### 1. Credited-effect asset check: `&&` → `||` (fund-safety)
`processTransaction` skipped an `account_credited` effect only when **both** the asset code **and** the issuer were wrong:
```go
if creditedEffect.Code != asset[0] && creditedEffect.Issuer != asset[1] { continue }
```
So a credit with the **right code but a forged/wrong issuer** (or vice-versa) passed the gate. This is the only asset gate before the mint amount is summed. Fixed to require both to match (consistent with the `||`-form check already used elsewhere in the file).

### 2. Per-op loop: `return nil, nil` → `continue` (fund-safety)
The operation loop returned from the **entire function** on the first non-payment operation, silently discarding any legitimate payment ops later in the same transaction → **lost deposits / missing mints**. Now skips non-payment ops individually.

### 3. Operation-level asset validation (defense-in-depth)
The effect check gates entry to the loop, but each payment **amount** was summed without re-checking its asset. Added a per-payment `Code`/`Issuer` guard so a non-TFT payment to the bridge in the same transaction can't be minted as TFT; non-TFT payments are skipped and logged as an alert.

### 4. `StatBridgeAccount`: `||` → `&&`
Balance lookup matched on code **or** issuer, so it could return an unrelated asset's balance. Now matches on both. (Observability only — not fund-moving.)

## Logic reasoning & regression-vector verification

- **Do legitimate TFT deposits still mint?** Yes. A real TFT deposit has the canonical `(code, issuer)`, so it passes both the `||` effect gate and the new op-level guard unchanged.
- **Can fix #1 now wrongly *reject* good deposits?** No — rejection only happens when code or issuer doesn't match the configured TFT asset, which a genuine TFT deposit never does.
- **Can fix #2 now mint something it shouldn't?** No — the op loop still requires `op.GetType() == "payment"`, `To == bridge && From != bridge`, and (new) the TFT asset match. `continue` only lets *later* ops be evaluated under those same guards instead of aborting the tx.
- **Native XLM / other assets:** native and non-TFT payments have a non-matching `Code`/`Issuer` → skipped+logged by fix #3. No mint.
- **Fix #4:** native balance (empty code/issuer) and foreign assets no longer match; only the exact TFT trustline balance is returned. Returns the existing "no trustline" error if absent (unchanged behavior).

## Testing
- `go build ./...` — OK
- `go vet ./pkg/stellar/...` — OK
- `gofmt -l` — clean

The bridge has no Go unit harness for `processTransaction`; changes are surgical and reasoned above. (A decode/mint unit test is a worthwhile follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)