### PR TITLE
fix(bridge): correct error wrapping, trace_id key, and a log message

### DIFF
--- a/bridge/tfchain_bridge/pkg/bridge/bridge.go
+++ b/bridge/tfchain_bridge/pkg/bridge/bridge.go
@@ -146,7 +146,7 @@ func (bridge *Bridge) Start(ctx context.Context) error {
 		select {
 		case data := <-tfchainSub:
 			if data.Err != nil {
-				return errors.Wrap(err, "failed to get tfchain events")
+				return errors.Wrap(data.Err, "failed to get tfchain events")
 			}
 			for _, withdrawCreatedEvent := range data.Events.WithdrawCreatedEvents {
 				err := bridge.handleWithdrawCreated(ctx, withdrawCreatedEvent)
@@ -190,7 +190,7 @@ func (bridge *Bridge) Start(ctx context.Context) error {
 			}
 		case data := <-stellarSub:
 			if data.Err != nil {
-				return errors.Wrap(err, "failed to get stellar payments")
+				return errors.Wrap(data.Err, "failed to get stellar payments")
 			}
 
 			for _, mEvent := range data.Events {

--- a/bridge/tfchain_bridge/pkg/stellar/stellar.go
+++ b/bridge/tfchain_bridge/pkg/stellar/stellar.go
@@ -368,7 +368,7 @@ func (w *StellarWallet) submitTransaction(ctx context.Context, txn *txnbuild.Tra
 		return errors.Wrap(err, "an error occurred while submitting the transaction")
 	}
 	log.Info().
-		Str("trace_id", fmt.Sprint(ctx.Value("trace_id"))).
+		Str("trace_id", fmt.Sprint(ctx.Value(TraceIdKey{}))).
 		Str("event_action", "stellar_transaction_submitted").
 		Str("event_kind", "event").
 		Str("category", "vault").

--- a/bridge/tfchain_bridge/pkg/substrate/client.go
+++ b/bridge/tfchain_bridge/pkg/substrate/client.go
@@ -63,7 +63,7 @@ func NewSubstrateClient(url string, seed string) (*SubstrateClient, error) {
 func (s *SubstrateClient) RetrySetWithdrawExecuted(ctx context.Context, tixd uint64) error {
 	err := s.SetBurnTransactionExecuted(s.identity, tixd)
 	for err != nil {
-		log.Err(err).Msg("error while setting refund transaction as executed")
+		log.Err(err).Msg("error while setting burn transaction as executed")
 
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
## Summary

Three small **diagnostics/observability** fixes in the bridge, decomposed out of the larger #1079 work. No change to fund flow or control flow — purely what gets logged/reported. Bridge-only, no runtime upgrade.

## Changes

### 1. Wrong error variable wrapped in `Bridge.Start` (`bridge.go:149,193`)
Both subscription arms check `data.Err != nil` but wrap the stale outer-scope `err`:
```go
case data := <-tfchainSub:
    if data.Err != nil {
        return errors.Wrap(err, "failed to get tfchain events") // wraps stale `err`, not data.Err
    }
```
A real subscription failure was therefore reported with the wrong (often nil/empty) cause, masking the actual error on the bridge's exit path. Fixed to wrap `data.Err` in both arms.

### 2. `trace_id` always logged as `<nil>` (`stellar.go:371`)
The `stellar_transaction_submitted` success log read the trace id with the **string** key `ctx.Value("trace_id")`, but the value is stored under the **typed** key `TraceIdKey{}` (set in `CreatePaymentWithSignaturesAndSubmit`/`CreateRefundPaymentWithSignaturesAndSubmit`). So every submitted-tx log line emitted `trace_id=<nil>`. Note the sibling underfunded-alert log at `stellar.go:356` already uses `TraceIdKey{}` correctly — this aligns the success log with it.

### 3. Copy-paste log message (`client.go:66`)
`RetrySetWithdrawExecuted` calls `SetBurnTransactionExecuted` but logged `"error while setting refund transaction as executed"`. Corrected to `"burn transaction"`.

## Logic reasoning & regression-vector verification

- **#1:** Both branches are entered only when `data.Err != nil`, so `data.Err` is guaranteed non-nil where it's now wrapped — strictly more correct, no nil-wrap risk. Control flow unchanged (still returns).
- **#2:** The `ctx` reaching `submitTransaction` is `ctx_with_trace_id` (carries `TraceIdKey{}`), so the value resolves correctly now. Pure logging value; no control-flow effect.
- **#3:** String-literal change only.

## Testing
- `go build ./...` — OK
- `go vet ./...` — OK
- `gofmt -l` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)