### PR TITLE
fix(tfchain-client-js): fix stale runtime assumptions in read wrappers (twin ip, entity storage, null crashes)

### DIFF
--- a/clients/tfchain-client-js/lib/entity.js
+++ b/clients/tfchain-client-js/lib/entity.js
@@ -30,7 +30,9 @@ async function getEntity (self, id) {
   const entity = await self.api.query.tfgridModule.entities(id)
 
   const res = entity.toJSON()
-  if (res.id !== id) {
+  // A non-existent entity decodes to null; guard before reading fields so we
+  // throw a clean "No such entity" instead of a TypeError on null.
+  if (!res || res.id !== id) {
     throw Error('No such entity')
   }
 
@@ -39,15 +41,20 @@ async function getEntity (self, id) {
 }
 
 async function getEntityIDByName (self, name) {
-  const entity = await self.api.query.tfgridModule.entitiesByNameID(name)
+  // Storage was renamed on the current runtime: entitiesByNameID -> entityIdByName.
+  const entity = await self.api.query.tfgridModule.entityIdByName(name)
 
-  return entity.toJSON()
+  // Normalize not-found to 0 (the storage may decode to null), preserving the
+  // "0 means absent" contract that callers (e.g. activation-service) rely on.
+  return entity.toJSON() || 0
 }
 
 async function getEntityIDByPubkey (self, pubkey) {
-  const entity = await self.api.query.tfgridModule.entitiesByPubkeyID(pubkey)
+  // Storage was renamed on the current runtime: entitiesByPubkeyID -> entityIdByAccountID.
+  const entity = await self.api.query.tfgridModule.entityIdByAccountID(pubkey)
 
-  return entity.toJSON()
+  // Normalize not-found to 0 (decodes to null), preserving the "0 means absent" contract.
+  return entity.toJSON() || 0
 }
 
 async function listEntities (self) {

--- a/clients/tfchain-client-js/lib/node.js
+++ b/clients/tfchain-client-js/lib/node.js
@@ -63,7 +63,9 @@ async function getNode (self, id) {
   const node = await self.api.query.tfgridModule.nodes(id)
 
   const res = node.toJSON()
-  if (res.id !== id) {
+  // A non-existent node decodes to null; guard before reading fields so we throw
+  // a clean "No such node" instead of a TypeError on null.
+  if (!res || res.id !== id) {
     throw Error('No such node')
   }
 

--- a/clients/tfchain-client-js/lib/node.js
+++ b/clients/tfchain-client-js/lib/node.js
@@ -69,27 +69,35 @@ async function getNode (self, id) {
     throw Error('No such node')
   }
 
-  // Decode location
+  // Decode location. On the current runtime city/country/latitude/longitude are
+  // all nested under `location` and byte-encoded. The previous code decoded only
+  // lat/long and read `res.country`/`res.city` at the top level — where they do
+  // not exist — so city/country were left hex-encoded.
   const { location } = res
-  const { longitude = '', latitude = '' } = location
-  location.longitude = hex2a(longitude)
-  location.latitude = hex2a(latitude)
-
-  if (res.country) {
-    res.country = hex2a(res.country)
+  if (location) {
+    location.longitude = hex2a(location.longitude)
+    location.latitude = hex2a(location.latitude)
+    location.city = hex2a(location.city)
+    location.country = hex2a(location.country)
   }
 
-  if (res.city) {
-    res.city = hex2a(res.city)
-  }
-
-  const { public_config: publicConfig } = res
+  // On the current runtime the field decodes as `publicConfig` (camelCase) with a
+  // nested shape: { ip4: { ip, gw }, ip6: { ip, gw }, domain }. The previous code
+  // read `public_config` (snake) with a flat { ipv4, ipv6, gw4, gw6 } shape, so it
+  // matched nothing and left everything hex-encoded.
+  const { publicConfig } = res
   if (publicConfig) {
-    const { ipv4, ipv6, gw4, gw6 } = publicConfig
-    publicConfig.ipv4 = hex2a(ipv4)
-    publicConfig.ipv6 = hex2a(ipv6)
-    publicConfig.gw4 = hex2a(gw4)
-    publicConfig.gw6 = hex2a(gw6)
+    if (publicConfig.ip4) {
+      publicConfig.ip4.ip = hex2a(publicConfig.ip4.ip)
+      publicConfig.ip4.gw = hex2a(publicConfig.ip4.gw)
+    }
+    if (publicConfig.ip6) {
+      publicConfig.ip6.ip = hex2a(publicConfig.ip6.ip)
+      publicConfig.ip6.gw = hex2a(publicConfig.ip6.gw)
+    }
+    if (publicConfig.domain) {
+      publicConfig.domain = hex2a(publicConfig.domain)
+    }
   }
 
   if (res.serialNumber) {

--- a/clients/tfchain-client-js/lib/pricing_policy.js
+++ b/clients/tfchain-client-js/lib/pricing_policy.js
@@ -1,7 +1,15 @@
+const { hex2a } = require('./util')
+
 async function getPricingPolicyById (self, policyId) {
   const value = await self.api.query.tfgridModule.pricingPolicies(policyId)
 
-  return value.toJSON()
+  const res = value.toJSON()
+  // The policy `name` is byte-encoded; decode it to a string. A non-existent
+  // policy decodes to null, so guard before touching fields.
+  if (res && res.name) {
+    res.name = hex2a(res.name)
+  }
+  return res
 }
 module.exports = {
   getPricingPolicyById

--- a/clients/tfchain-client-js/lib/twin.js
+++ b/clients/tfchain-client-js/lib/twin.js
@@ -50,7 +50,8 @@ async function getTwin (self, id) {
   // The Twin struct no longer has an `ip` field (migrated to `relay`/`pk` long
   // ago). Return the metadata-decoded object as-is; decoding a non-existent
   // field threw `Cannot read properties of undefined` on the current runtime (#1090).
-  if (res.id !== id) {
+  // A non-existent twin decodes to null — guard before reading `id`.
+  if (!res || res.id !== id) {
     throw Error('No such twin')
   }
   return res

--- a/clients/tfchain-client-js/lib/twin.js
+++ b/clients/tfchain-client-js/lib/twin.js
@@ -1,5 +1,3 @@
-const { hex2a } = require('./util')
-
 // createTwin creates an entity with given name
 async function createTwin (self, relay, pk, callback) {
   const create = self.api.tx.tfgridModule.createTwin(relay, pk)
@@ -49,7 +47,9 @@ async function getTwin (self, id) {
   const twin = await self.api.query.tfgridModule.twins(id)
 
   const res = twin.toJSON()
-  res.ip = hex2a(res.ip)
+  // The Twin struct no longer has an `ip` field (migrated to `relay`/`pk` long
+  // ago). Return the metadata-decoded object as-is; decoding a non-existent
+  // field threw `Cannot read properties of undefined` on the current runtime (#1090).
   if (res.id !== id) {
     throw Error('No such twin')
   }
@@ -69,10 +69,8 @@ async function listTwins (self) {
   const twins = await self.api.query.tfgridModule.twins.entries()
 
   const parsedTwins = twins.map(twin => {
-    const parsedTwin = twin[1].toJSON()
-    parsedTwin.ip = hex2a(parsedTwin.ip)
-
-    return parsedTwin
+    // See getTwin: no `ip` field on the current runtime — return as-is (#1090).
+    return twin[1].toJSON()
   })
 
   return parsedTwins

--- a/clients/tfchain-client-js/lib/util.js
+++ b/clients/tfchain-client-js/lib/util.js
@@ -1,4 +1,9 @@
 function hex2a (hex) {
+  // Guard against absent/null fields. On the current runtime several previously
+  // byte-encoded fields are Option<...> (decoded as null) or were removed
+  // entirely, so callers may pass undefined/null. Returning '' keeps the read
+  // wrappers from throwing `Cannot read properties of undefined`.
+  if (hex === undefined || hex === null) return ''
   let str = ''
   for (let i = 0; i < hex.length; i += 2) {
     const v = parseInt(hex.substr(i, 2), 16)

--- a/clients/tfchain-client-js/package.json
+++ b/clients/tfchain-client-js/package.json
@@ -4,7 +4,7 @@
   "description": "API client for the TF Grid",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test test/"
   },
   "author": "",
   "license": "ISC",

--- a/clients/tfchain-client-js/test/util.test.js
+++ b/clients/tfchain-client-js/test/util.test.js
@@ -1,0 +1,27 @@
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { hex2a } = require('../lib/util')
+
+test('hex2a decodes a 0x-prefixed hex string to ASCII', () => {
+  // "test" = 0x74657374
+  assert.strictEqual(hex2a('0x74657374'), 'test')
+})
+
+test('hex2a decodes a bare (no-0x) hex string to ASCII', () => {
+  assert.strictEqual(hex2a('74657374'), 'test')
+})
+
+test('hex2a returns empty string for undefined (absent field on current runtime)', () => {
+  // Regression for #1090: twin/node/farm read wrappers call hex2a on fields
+  // that no longer exist on the current runtime; this must not throw.
+  assert.strictEqual(hex2a(undefined), '')
+})
+
+test('hex2a returns empty string for null (Option field decoded as null)', () => {
+  assert.strictEqual(hex2a(null), '')
+})
+
+test('hex2a returns empty string for empty input', () => {
+  assert.strictEqual(hex2a(''), '')
+  assert.strictEqual(hex2a('0x'), '')
+})


### PR DESCRIPTION
Closes #1090, #1102. Expanded from the original twin-`ip` fix after **live devnet testing** surfaced a cluster of bugs of the same class — stale runtime assumptions in the barely-maintained read wrappers. Every fix below is verified live against devnet (spec 157).

## Bugs fixed

**1. twin `ip` crash (#1090)** — `getTwin`/`listTwins` decoded a non-existent `ip` field; `hex2a(undefined)` threw. Removed the stale decode and **hardened `hex2a` to return `''` on `undefined`/`null`** (the root of the crash class — `hex2a` is called on ~16 fields, several now `Option`/null).

**2. Entity lookups queried dead storage (critical — broke activation-service)**
- `getEntityIDByName` → `entitiesByNameID` (gone) → `entityIdByName`
- `getEntityIDByPubkey` → `entitiesByPubkeyID` (gone) → `entityIdByAccountID`
- Both threw `is not a function`. **activation-service's `createEntity` calls both**, so it was broken against the current runtime. Also normalize not-found → `0` (new storage decodes to `null`).

**3. Null crashes on non-existent ids** — `getEntity`/`getNode`/`getTwin` did `res.id` on a `null` decode. Guarded to throw a clean `No such <x>`.

**4. `getNode` returned un-decoded data (wrong key + wrong structure)**
- Public config: read `res.public_config` (snake, doesn't exist) with a flat `{ipv4,ipv6,gw4,gw6}` shape → nothing decoded. Fixed to `publicConfig` with the real nested shape `{ ip4:{ip,gw}, ip6:{ip,gw}, domain }`.
- `city`/`country` are nested under `location` (not top-level) → never decoded. Now decoded inside `location` alongside lat/long.

**5. `getPricingPolicyById`** returned the policy `name` as raw hex → now `hex2a`-decoded.

## Live verification (devnet, spec 157)
```
getEntityIDByName("x")    -> 0      (was: not a function)
getEntityIDByPubkey(acc)  -> 0      (was: not a function)
getEntityByID(1)          -> throws "No such entity"  (was: null crash)
getNodeByID(1)            -> throws "No such node"    (was: null crash)
getTwinByID(999999)       -> throws "No such twin"    (was: null crash)
getTwinByID(1)            -> {id:1, ..., relay:null, pk:null}            ✓
listTwins()               -> 21166 twins, no crash                       ✓
getNodeByID(50).location  -> {city:"Bartlesville", country:"United States", lat/long}  ✓ (was hex)
getNodeByID(50).publicConfig -> {ip4:{ip:"162.205.240.200/25",gw:...}, ip6, domain:"virt3.tfcloud.us"}  ✓ (was hex)
getPricingPolicyById(1).name -> "threefold_default_pricing_policy"        ✓ (was hex)
getBalanceOf, getFarmByID, getContractByID                                ✓
```

## Note correcting the activation-service compatibility assessment
Earlier static analysis concluded activation-service was API-compatible with the v2 client because the method names exist. **Live testing disproved that** for `createEntity`: the methods existed but queried dead storage. This PR is what actually makes the client work against the current runtime — directly relevant to the activation-service v2 upgrade (#1099).

## Tests
- `test/util.test.js` for `hex2a` (built-in `node:test`, no new deps); `test` script wired up.
- The read wrappers need a live `api`, so they're covered by the devnet runs above rather than unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

