### PR TITLE
fix(activation-service): stop leaking internal errors, drop unused KYC_PUBLIC_KEY

### DIFF
--- a/activation-service/bin/www
+++ b/activation-service/bin/www
@@ -8,10 +8,13 @@ const { init } = require('../lib/substrate')
 
 const log = require('../lib/logger')
 
+// KYC_PUBLIC_KEY used to be required here, but nothing has read it since the
+// signature-verification code was commented out. Its last referent went away with
+// the /create-entity route in #1103. Requiring an unused variable only makes the
+// service refuse to start for no reason; re-add it here if KYC checks come back.
 const REQUIRED_ENV_VARIABLES = [
   'MNEMONIC',
   'URL',
-  'KYC_PUBLIC_KEY',
   'ACTIVATION_AMOUNT'
 ]
 

--- a/activation-service/helm/tfchainactivationservice/templates/deployment.yaml
+++ b/activation-service/helm/tfchainactivationservice/templates/deployment.yaml
@@ -34,8 +34,6 @@ spec:
             value: {{ .Values.url }}
           - name: MNEMONIC
             value: {{ .Values.mnemonic }}
-          - name: KYC_PUBLIC_KEY
-            value: {{ .Values.kyc_public_key }}
           - name: ACTIVATION_AMOUNT
             value: {{ .Values.activation_amount | quote }}
           ports:

--- a/activation-service/helm/tfchainactivationservice/values.yaml
+++ b/activation-service/helm/tfchainactivationservice/values.yaml
@@ -49,7 +49,6 @@ ingress:
 
 url: wss://tfchain.dev.threefold.io
 mnemonic:
-kyc_public_key: "somekey"
 # Amount to fund a new account with, in whole TFT. Decimals are allowed down to
 # 1e-7 TFT. Amounts below the chain's existential deposit are rejected at startup,
 # because such a transfer cannot create an account.

--- a/activation-service/index.js
+++ b/activation-service/index.js
@@ -1,14 +1,11 @@
+const { STATUS_CODES } = require('node:http')
+
 const express = require('express')
 const cors = require('cors')
 const httpError = require('http-errors')
-const { omit } = require('lodash')
 
 // attach env variables to process.env
 require('dotenv').config()
-
-const {
-  NODE_ENV = 'development'
-} = process.env
 
 const log = require('./lib/logger')
 
@@ -29,17 +26,26 @@ app.use('/activation', require('./routes'))
 app.use((req, res, next) => next(httpError.NotFound()))
 
 app.use(function (err, req, res, next) {
-  if (httpError.isHttpError(err)) {
-    // use warning since we threw the error
-    log.warn(err)
-    res.status(err.status)
-    if (NODE_ENV !== 'development') return res.send(omit(err, ['stack']))
-    return res.send(err)
+  const status = err.status || err.statusCode || 500
+
+  if (status >= 500) {
+    log.error({ err }, 'error happened handling the request')
+  } else {
+    // The caller sent something unusable; that is not a fault on our side.
+    log.warn({ err }, 'rejected the request')
   }
 
-  // default error handler
-  log.error(err, 'error happened handling the request')
-  res.status(err.status || 500).send(err.message)
+  // http-errors sets `expose` true for 4xx and false for 5xx: a client caused a
+  // 4xx and needs to know why, whereas a 5xx message describes our internals.
+  //
+  // That flag used to be computed and then ignored. Both branches of the old
+  // NODE_ENV check sent the message regardless — lodash's omit copies `message`
+  // through, so the "production" path returned things like the decoded chain
+  // error alongside `expose: false`, and the development path (the default,
+  // since NODE_ENV is set nowhere) added the stack trace.
+  res.status(status).json({
+    message: err.expose ? err.message : STATUS_CODES[status]
+  })
 })
 
 module.exports = app

--- a/activation-service/readme.md
+++ b/activation-service/readme.md
@@ -11,7 +11,6 @@ create `.env` file with following content:
 ```
 URL=wss://substrate01.threefold.io
 MNEMONIC=substrate ed25519 private words
-KYC_PUBLIC_KEY=kyc service 25119 public key
 ACTIVATION_AMOUNT=1
 ```
 
@@ -38,7 +37,11 @@ yarn start
 
 `/activation/activate`
 
-Activates a Substrate account and puts 500 tokens on it.
+Funds a Substrate account with `ACTIVATION_AMOUNT` if it is empty, or tops it back
+up to the minimum extrinsic cost if its balance has fallen below that.
+
+Returns 400 for an account id that is not a valid 32 byte public key, and 5xx if
+the transfer fails on chain — including when the funding account is itself empty.
 
 Example: Post to `localhost:3000/activation/activate`
 
@@ -49,22 +52,15 @@ curl --header "Content-Type: application/json" \
   http://localhost:3000/activation/activate
 ```
 
-### Create Entity
-
-`/activation/create-entity`
-
-Creates an entity object in the griddb.
-
 ## KYC
 
-The KYC signature is currently not validated 
-
+The KYC signature is not validated. The verification code has been commented out
+for years, and `POST /activation/create-entity` — its only caller — was removed in
+#1103, having been an unauthenticated route that signed a fee-paying extrinsic from
+the service wallet. `KYC_PUBLIC_KEY` is no longer read or required; re-add it if
+the checks come back.
 
 ## Deployment
 
-Build the docker image and configure following environment variables:
-
-```
-MNEMONIC=mnemonic words for account that activates
-URL=substrate websocket url
-```
+Build the docker image and configure the environment variables listed above.
+`ACTIVATION_AMOUNT` is required, so set it explicitly even though it has a default.


### PR DESCRIPTION
Two follow-ups from #1105. **Based on #1105, not `development`** — the readme text here describes `ACTIVATION_AMOUNT` as being read, which only becomes true with that PR. Retarget to `development` once it merges.

## 1. Internal error messages were returned to callers

The error middleware computed http-errors' `expose` flag and then ignored it. Both branches of the `NODE_ENV` check sent the message anyway, because lodash's `omit(err, ['stack'])` copies `message` through:

```js
omit(httpError(500, 'Insufficient Balance Error: ...'), ['stack'])
// => {"message":"Insufficient Balance Error: ...","status":500,"statusCode":500,"expose":false}
//                                                                              ^^^^^^^^^^^^^^
```

And the *development* branch — the default, since `NODE_ENV` is set in neither the Dockerfile nor the chart — sent the whole error including the stack trace. So every deployment has been running in the more verbose mode.

Verified against the built image: a request that failed because the funding account was empty replied with `Insufficient Balance Error: Failed to apply 'transfer' on section 'balances' with args '<address>,1000000.`

Now the flag decides. 4xx keeps its message, since the caller sent something unusable and needs to know what; 5xx returns the generic status text and the real error goes to the log only:

```
400 -> {"message":"substrateAccountID is not a valid account id"}
500 -> {"message":"Internal Server Error"}        # log: "error happened handling the request"
```

`NODE_ENV` no longer affects what is returned, so a deployment cannot leak by omitting it — which is what every deployment currently does.

**Behaviour change:** response bodies are now consistently `{ message }`. 4xx previously also carried `status`, `statusCode` and `expose`; non-http errors fell through to `res.send(err.message)` as text rather than JSON. The frontend catches errors and renders a fixed string without reading the body, so there is no UI impact.

## 2. `KYC_PUBLIC_KEY` was required but unread

It has been in `bin/www`'s required env variables since the service was written, but nothing reads it: the signature verification was commented out years ago and its only caller, `POST /activation/create-entity`, was removed in #1103 as an unauthenticated route that signed a fee-paying extrinsic from the service wallet. Requiring an unused variable only gives the service a reason to refuse to start.

Removed from the required list, the chart and the documented `.env`. Re-add it alongside the verification code if KYC checks return.

While in the readme, two claims that no longer held: it documented the removed `/activation/create-entity` endpoint, and said activation "puts 500 tokens" on an account — true in 2021, since reduced by three orders of magnitude.

## Verification

- lint + unit: 27/27
- live devnet: 400 exposes its message, 500 returns `Internal Server Error` while the underlying error still reaches the log, boot and SIGTERM unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YKJm3zuWdSepriT9KL9zy