### PR TITLE
ci: only build substrate when substrate changed, and supersede stale runs

### DIFF
--- a/.github/workflows/010_build_and_test.yaml
+++ b/.github/workflows/010_build_and_test.yaml
@@ -3,7 +3,26 @@ on:
   push:
     branches:
       - development
+    paths:
+      - 'substrate-node/**'
+      - '.github/workflows/010_build_and_test.yaml'
   pull_request:
+    # Every step of this job works inside substrate-node: cargo build, cargo test,
+    # and the robot suite in substrate-node/tests. It used to run on every pull
+    # request regardless, so a JS-only change queued a full Rust build.
+    paths:
+      - 'substrate-node/**'
+      - '.github/workflows/010_build_and_test.yaml'
+
+# One self-hosted runner serves this workflow, and the build starts with a
+# `cargo clean`, so runs are long and strictly serial. Without this, pushing three
+# times to a branch queued three full builds and only the last one's result
+# mattered. Superseding an in-progress build for the same ref is safe: the newest
+# commit is what the pull request is judged on.
+concurrency:
+  group: build-and-test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: [self-hosted, tfchainrunner01]


### PR DESCRIPTION
Three JS-only branches put **thirteen** CI runs in flight, most for commits that had already been superseded. Two causes, both in `010_build_and_test.yaml`.

## No path filter

It triggers on every `pull_request`, but every step works inside `substrate-node`:

```
cargo clean && cargo build --release          # substrate-node
cargo test --features runtime-benchmarks      # substrate-node
robot -d _output_tests/ .                     # substrate-node/tests
```

So a change to `activation-service` or `clients/tfchain-client-js` queued a full Rust build that could not report anything about it. Filtered to `substrate-node/**` plus the workflow file.

## No concurrency group

One self-hosted runner (`tfchainrunner01`) serves this, and the build opens with `cargo clean`, so runs are long and strictly serial. Every push added another to the queue while the earlier one was already irrelevant. Added a per-ref group with `cancel-in-progress: true` — safe, because a PR is judged on its newest commit and the older build's result was going to be thrown away.

## Two things I did not change

`cargo clean` before `cargo build --release` discards what the `actions/cache` step just restored, which is most of why each run is so long. Removing it would speed things up considerably, but it may be deliberate insurance against stale artifacts, so that is a call for whoever owns this pipeline.

`development` has **no required status checks** today, so a path-filtered skip cannot block a merge. Worth knowing that if this job is ever made required, GitHub reports a skipped workflow as *no status* rather than success, and these filters would need revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YKJm3zuWdSepriT9KL9zy